### PR TITLE
Add a null check in case there is no current equipped item

### DIFF
--- a/src/main/java/tconstruct/library/tools/HarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/HarvestTool.java
@@ -289,7 +289,10 @@ public abstract class HarvestTool extends ToolCore
         }
 
         // callback to the tool the player uses. Called on both sides. This damages the tool n stuff.
-        player.getCurrentEquippedItem().func_150999_a(world, block, x, y, z, player);
+        ItemStack currentItem = player.getCurrentEquippedItem();
+        if(currentItem != null) {
+            currentItem.func_150999_a(world, block, x, y, z, player);
+        }
 
         // server sided handling
         if (!world.isRemote) {


### PR DESCRIPTION
Guards against: 
```java
java.lang.NullPointerException: Exception in server tick loop
    at tconstruct.library.tools.HarvestTool.breakExtraBlock(HarvestTool.java:292)
    at tconstruct.items.tools.LumberAxe$TreeChopTask.onWorldTick(LumberAxe.java:256)
    at cpw.mods.fml.common.eventhandler.ASMEventHandler_1378_TreeChopTask_onWorldTick_WorldTickEvent.invoke(.dynamic)
    at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
    at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
    at cpw.mods.fml.common.FMLCommonHandler.onPreWorldTick(FMLCommonHandler.java:273)
    at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:957)
    at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:432)
    at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:841)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:693)
    at java.lang.Thread.run(Thread.java:748)
```