### PR TITLE
Add support for swapping belt toolbars in inventory GUIs.

### DIFF
--- a/resources/assets/tinker/lang/en_US.lang
+++ b/resources/assets/tinker/lang/en_US.lang
@@ -16,6 +16,8 @@ crafters.Smeltery=Smeltery
 crafters.Frypan=Frying Pan
 inventory.knapsack=Knapsack
 
+nei.options.keys.gui.tinkers_belt=Toggle Travellers Belt
+
 ToolStation.Crafter.name=Tool Station
 ToolStation.Parts.name=Part Builder
 ToolStation.PatternChest.name=Pattern Chest

--- a/src/main/java/tconstruct/client/ArmorControls.java
+++ b/src/main/java/tconstruct/client/ArmorControls.java
@@ -214,8 +214,7 @@ public class ArmorControls {
 		updateServer(packet);
 	}
 
-	public static boolean doBeltSwapIfPossible()
-	{
+	public static boolean doBeltSwapIfPossible() {
 		if (ArmorProxyClient.armorExtended.inventory[3] != null) {
 			PlayerAbilityHelper.swapBelt(mc.thePlayer, ArmorProxyClient.armorExtended);
 			toggleBelt();

--- a/src/main/java/tconstruct/client/ArmorControls.java
+++ b/src/main/java/tconstruct/client/ArmorControls.java
@@ -174,10 +174,7 @@ public class ArmorControls {
 				}
 			}
 			if (key == ArmorControls.beltSwap) {
-				if (ArmorProxyClient.armorExtended.inventory[3] != null) {
-					PlayerAbilityHelper.swapBelt(mc.thePlayer, ArmorProxyClient.armorExtended);
-					toggleBelt();
-				}
+				doBeltSwapIfPossible();
 			}
 			if (key == ArmorControls.zoomKey) {
 				zoom = !zoom;
@@ -217,7 +214,17 @@ public class ArmorControls {
 		updateServer(packet);
 	}
 
-	private void toggleBelt() {
+	public static boolean doBeltSwapIfPossible()
+	{
+		if (ArmorProxyClient.armorExtended.inventory[3] != null) {
+			PlayerAbilityHelper.swapBelt(mc.thePlayer, ArmorProxyClient.armorExtended);
+			toggleBelt();
+			return true;
+		}
+		return false;
+	}
+
+	private static void toggleBelt() {
 		AbstractPacket packet = new BeltPacket();
 		updateServer(packet);
 	}

--- a/src/main/java/tconstruct/plugins/nei/BeltToggleFromGuiInputHandler.java
+++ b/src/main/java/tconstruct/plugins/nei/BeltToggleFromGuiInputHandler.java
@@ -1,0 +1,67 @@
+package tconstruct.plugins.nei;
+
+import codechicken.nei.NEIClientConfig;
+import codechicken.nei.api.API;
+import codechicken.nei.guihook.GuiContainerManager;
+import codechicken.nei.guihook.IContainerInputHandler;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import tconstruct.client.ArmorControls;
+
+public class BeltToggleFromGuiInputHandler implements IContainerInputHandler {
+
+    static final String KEY_IDENTIFIER = "gui.tinkers_belt";
+    public static void init() {
+        API.addKeyBind(KEY_IDENTIFIER, 0);
+        GuiContainerManager.addInputHandler((IContainerInputHandler)new BeltToggleFromGuiInputHandler());
+    }
+
+    @Override
+    public boolean keyTyped(GuiContainer guiContainer, char c, int i) {
+        final int keyBinding = NEIClientConfig.getKeyBinding(KEY_IDENTIFIER);
+        if (i != keyBinding) {
+            return false;
+        }
+
+        return ArmorControls.doBeltSwapIfPossible();
+    }
+
+    @Override
+    public void onKeyTyped(GuiContainer guiContainer, char c, int i) {
+
+    }
+
+    @Override
+    public boolean lastKeyTyped(GuiContainer guiContainer, char c, int i) {
+        return false;
+    }
+
+    @Override
+    public boolean mouseClicked(GuiContainer guiContainer, int i, int i1, int i2) {
+        return false;
+    }
+
+    @Override
+    public void onMouseClicked(GuiContainer guiContainer, int i, int i1, int i2) {
+
+    }
+
+    @Override
+    public void onMouseUp(GuiContainer guiContainer, int i, int i1, int i2) {
+
+    }
+
+    @Override
+    public boolean mouseScrolled(GuiContainer guiContainer, int i, int i1, int i2) {
+        return false;
+    }
+
+    @Override
+    public void onMouseScrolled(GuiContainer guiContainer, int i, int i1, int i2) {
+
+    }
+
+    @Override
+    public void onMouseDragged(GuiContainer guiContainer, int i, int i1, int i2, long l) {
+
+    }
+}

--- a/src/main/java/tconstruct/plugins/nei/NEITConstructConfig.java
+++ b/src/main/java/tconstruct/plugins/nei/NEITConstructConfig.java
@@ -19,6 +19,8 @@ public class NEITConstructConfig implements IConfigureNEI
         registerHandler(new RecipeHandlerAlloying());
         registerHandler(new RecipeHandlerCastingTable());
         registerHandler(new RecipeHandlerCastingBasin());
+
+        BeltToggleFromGuiInputHandler.init();
     }
 
     @Override


### PR DESCRIPTION
This adds support for swapping toolbars in GUIs. It uses a separate keybinding (due to how NEI works) that is currently not set by default, so one must explicitly bind it in the NEI options for now. It's a client side only fix.