### PR TITLE
Add a fall back if we try to look up a missing material

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,6 +4,6 @@ mantle_version=0.3.2.jenkins187
 CCLIB_version=1.1.3.136
 NEI_version=1.0.4.106
 ccc_version=1.0.6.43
-mod_version=1.9.0.2-GTNH
+mod_version=1.9.0.3-GTNH
 waila_version=1.5.3_1.7.10
 fmp_version=1.1.2.334

--- a/src/main/java/tconstruct/library/TConstructRegistry.java
+++ b/src/main/java/tconstruct/library/TConstructRegistry.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.*;
 import tconstruct.library.crafting.*;
 import tconstruct.library.modifier.ActiveArmorMod;
 import tconstruct.library.tools.*;
+import tconstruct.tools.TinkerTools;
 
 /**
  * A registry to store any relevant API work
@@ -371,7 +372,14 @@ public class TConstructRegistry
 
     public static ToolMaterial getMaterial (int key)
     {
-        return (toolMaterials.get(key));
+        if (toolMaterials.containsKey(key))
+        {
+            return (toolMaterials.get(key));
+        }
+
+        // This is probably an old tool whose material has been removed from the game.
+        // Fall back to wood.
+        return toolMaterials.get(TinkerTools.MaterialID.Wood);
     }
 
     /**


### PR DESCRIPTION
@Prometheus0000, this is the follow-on PR for:
 * https://github.com/GTNewHorizons/TinkersGregworks/pull/6

This PR fixes the super-bugged item issue that I mentioned in the PR above. With both of these PRs, I think deleting materials works okay, though there is still some weirdness. We could also use some other material instead of `Wood` as a fallback, though tools keep their old stats so it may not make much difference.

I tried testing with deleting Oureclase with a minimal testing set of mods, and here's what I saw happen:

Tinker's tools using the bugged material have those parts replaced with "Wood", but they still retain the same stats as the deleted material used to have. The tool seems to work just fine, though it has a tooltip saying that it should be placed in a crafting grid to fix some bad data. Placing the tool in a crafting grid does absolutely nothing, though, and you get the exact same semi-bugged tool back out (maybe due to IguanaTweaks overriding some of Tinker's handlers?). Replacing parts also doesn't seem to work: it'll consume the part, but the tool's stats don't change, and it continues to be made of "Wood". Repairing doesn't seem to work either, though adding modifiers does work. Anyway, it doesn't crash, and I guess having the same stats as before isn't terrible, since the player did earn those stats prior to the material's removal.

Tinker's parts (e.g. hammer head) made of the bugged material no longer render with any color. They cannot be used to replace parts in an existing tool, but they can be used to craft an entirely new Tinker's tool. If you do this, the crafted tool ends up with Wood in place of the deleted material. I didn't look closely, but I think this is non-bugged Wood, with the correct stats.

---

(Non-Tinker's testing below; shouldn't affect this PR as this PR is for Tinker's)

I think you mentioned this already, but to confirm, GregTech tools have their material changed to NULL, which seems to have high durability, though the attack and mining speed seem to be bad. The damage bar also doesn't seem to render. I guess this isn't so great, but at least it doesn't seem to crash.

GregTech parts (plates, ingots, pickaxe head) become invisible and lose their name and recipes. So they are basically just invisible, useless items that you can throw in the trash, if you can even find them in your inventory. At least they don't crash.