### PR TITLE
keybinds

### DIFF
--- a/src/main/java/tconstruct/client/ArmorControls.java
+++ b/src/main/java/tconstruct/client/ArmorControls.java
@@ -27,7 +27,7 @@ import tconstruct.util.network.GogglePacket;
 public class ArmorControls {
 
     public static final String keybindCategory = "tconstruct.keybindings";
-    public static final String[] keyDescs = new String[]{"key.tarmor", "key.tgoggles", "key.tbelt", "key.tzoom"};
+    public static final String[] keyDescs = new String[] {"key.tarmor", "key.tgoggles", "key.tbelt", "key.tzoom"};
     public static KeyBinding armorKey = new KeyBinding(keyDescs[0], Keyboard.KEY_NONE, keybindCategory);
     public static KeyBinding toggleGoggles = new KeyBinding(keyDescs[1], Keyboard.KEY_NONE, keybindCategory);
     public static KeyBinding beltSwap = new KeyBinding(keyDescs[2], Keyboard.KEY_NONE, keybindCategory);

--- a/src/main/java/tconstruct/client/ArmorControls.java
+++ b/src/main/java/tconstruct/client/ArmorControls.java
@@ -13,6 +13,7 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
+import org.lwjgl.input.Keyboard;
 import tconstruct.TConstruct;
 import tconstruct.armor.ArmorProxyClient;
 import tconstruct.armor.ArmorProxyCommon;
@@ -26,12 +27,12 @@ import tconstruct.util.network.GogglePacket;
 public class ArmorControls {
 
     public static final String keybindCategory = "tconstruct.keybindings";
-    public static final String[] keyDescs = new String[] {"key.tarmor", "key.tgoggles", "key.tbelt", "key.tzoom"};
-    public static KeyBinding armorKey = new KeyBinding(keyDescs[0], 24, keybindCategory);
-    public static KeyBinding toggleGoggles = new KeyBinding(keyDescs[1], 34, keybindCategory);
-    public static KeyBinding beltSwap = new KeyBinding(keyDescs[2], 48, keybindCategory);
-    public static KeyBinding zoomKey =
-            new KeyBinding(keyDescs[3], 44, keybindCategory); // TODO: Make this hold, not toggle
+    public static final String[] keyDescs = new String[]{"key.tarmor", "key.tgoggles", "key.tbelt", "key.tzoom"};
+    public static KeyBinding armorKey = new KeyBinding(keyDescs[0], Keyboard.KEY_NONE, keybindCategory);
+    public static KeyBinding toggleGoggles = new KeyBinding(keyDescs[1], Keyboard.KEY_NONE, keybindCategory);
+    public static KeyBinding beltSwap = new KeyBinding(keyDescs[2], Keyboard.KEY_NONE, keybindCategory);
+    // TODO: Make this hold, not toggle
+    public static KeyBinding zoomKey = new KeyBinding(keyDescs[3], Keyboard.KEY_NONE, keybindCategory);
     static KeyBinding jumpKey;
     static KeyBinding invKey;
     static Minecraft mc;


### PR DESCRIPTION
The goal is to unbind all keys that are not used from the start of the game in the GTNH modpack to avoid all the current keybinds conflict and leave to the user the choice of the keybinds they want.