### PR TITLE
adding the config options from the tinkered constructor fork

### DIFF
--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -286,6 +286,8 @@ public class TConstruct {
 
         @SubscribeEvent
         public void onEntitySpawn(EntityJoinWorldEvent event) {
+            // return if config is zero to keep vanilla functionality
+            if (PHConstruct.globalDespawn == 0) return;
             if (event.entity instanceof EntityItem) {
                 EntityItem ourGuy = (EntityItem) event.entity;
                 if (ourGuy.lifespan == 6000) {

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -6,8 +6,10 @@ import java.util.Random;
 import mantle.pulsar.config.ForgeCFG;
 import mantle.pulsar.control.PulseManager;
 
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.world.gen.structure.MapGenStructureIO;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,6 +60,7 @@ import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.*;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.network.NetworkCheckHandler;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -182,6 +185,8 @@ public class TConstruct {
         MinecraftForge.EVENT_BUS.register(playerTracker);
         NetworkRegistry.INSTANCE.registerGuiHandler(TConstruct.instance, proxy);
 
+        if (PHConstruct.globalDespawn != 6000) MinecraftForge.EVENT_BUS.register(new Spawntercepter());
+
         pulsar.preInit(event);
 
         if (PHConstruct.achievementsEnabled) {
@@ -274,6 +279,19 @@ public class TConstruct {
         // this will be called because the air-block got removed
         for (FMLMissingMappingsEvent.MissingMapping mapping : event.get()) {
             if (mapping.name.equals("TConstruct:TankAir")) mapping.ignore();
+        }
+    }
+
+    public static class Spawntercepter {
+
+        @SubscribeEvent
+        public void onEntitySpawn(EntityJoinWorldEvent event) {
+            if (event.entity instanceof EntityItem) {
+                EntityItem ourGuy = (EntityItem) event.entity;
+                if (ourGuy.lifespan == 6000) {
+                    ourGuy.lifespan = PHConstruct.globalDespawn;
+                }
+            }
         }
     }
 }

--- a/src/main/java/tconstruct/armor/player/ArmorExtended.java
+++ b/src/main/java/tconstruct/armor/player/ArmorExtended.java
@@ -14,6 +14,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
 import tconstruct.library.accessory.IHealthAccessory;
+import tconstruct.util.config.PHConstruct;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.relauncher.Side;
@@ -230,9 +231,10 @@ public class ArmorExtended implements IInventory {
     // ---
 
     public void dropItems() {
+        final int dropEndSlot = PHConstruct.dropCanisters ? 7 : 4;
         EntityPlayer player = parent.get();
         if (player != null) {
-            for (int i = 0; i < 4; ++i) {
+            for (int i = 0; i < dropEndSlot; ++i) {
                 if (this.inventory[i] != null && !isSoulBounded(this.inventory[i])) {
                     player.func_146097_a(this.inventory[i], true, false);
                     this.inventory[i] = null;

--- a/src/main/java/tconstruct/library/tools/AbilityHelper.java
+++ b/src/main/java/tconstruct/library/tools/AbilityHelper.java
@@ -58,11 +58,11 @@ public class AbilityHelper {
     }
 
     public static boolean onLeftClickEntity(ItemStack stack, EntityLivingBase player, Entity entity, ToolCore tool) {
-        return onLeftClickEntity(stack, player, entity, tool, 0);
+        return onLeftClickEntity(stack, player, entity, tool, 1);
     }
 
     public static boolean onLeftClickEntity(ItemStack stack, EntityLivingBase player, Entity entity, ToolCore tool,
-            int baseDamage) {
+            double damageFactor) {
         if (entity != null && player != null && entity.canAttackWithItem() && stack.hasTagCompound()) {
             if (!entity.hitByEntity(player)) // can't attack this entity
             {
@@ -75,8 +75,8 @@ public class AbilityHelper {
 
                 float stoneboundDamage = (float) Math.log(durability / 72f + 1) * -2 * stonebound;
 
-                int damage = calcDamage(player, entity, stack, tool, toolTags, baseDamage);
-                float knockback = calcKnockback(player, entity, stack, tool, toolTags, baseDamage);
+                int damage = calcDamage(player, entity, stack, tool, toolTags, damageFactor);
+                float knockback = calcKnockback(player, entity, stack, tool, toolTags);
 
                 float enchantDamage = 0;
 
@@ -108,8 +108,7 @@ public class AbilityHelper {
                     }
 
                     if (broken) {
-                        if (baseDamage > 0) damage = baseDamage;
-                        else damage = 1;
+                        damage = 1;
                     }
                     boolean causedDamage;
                     boolean isAlive = entity.isEntityAlive();
@@ -197,10 +196,10 @@ public class AbilityHelper {
     }
 
     public static int calcDamage(Entity user, Entity entity, ItemStack stack, ToolCore tool, NBTTagCompound toolTags,
-            int baseDamage) {
+            double damageFactor) {
         EntityLivingBase living = user instanceof EntityLivingBase ? (EntityLivingBase) user : null;
 
-        int damage = toolTags.getInteger("Attack") + baseDamage;
+        int damage = toolTags.getInteger("Attack");
         int earlyModDamage = 0;
         for (ActiveToolMod mod : TConstructRegistry.activeModifiers) {
             earlyModDamage = mod.baseAttackDamage(
@@ -242,11 +241,13 @@ public class AbilityHelper {
         }
         damage += modDamage;
 
+        damage *= damageFactor;
+
         return damage;
     }
 
     public static float calcKnockback(Entity user, Entity entity, ItemStack stack, ToolCore tool,
-            NBTTagCompound toolTags, int baseDamage) {
+            NBTTagCompound toolTags) {
         if (user == null) return 0;
         float knockback = 0;
 

--- a/src/main/java/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/tconstruct/library/tools/ToolCore.java
@@ -515,7 +515,7 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
     // Attacking
     @Override
     public boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity entity) {
-        return AbilityHelper.onLeftClickEntity(stack, player, entity, this, 0);
+        return AbilityHelper.onLeftClickEntity(stack, player, entity, this);
     }
 
     @Override

--- a/src/main/java/tconstruct/tools/entity/DaggerEntity.java
+++ b/src/main/java/tconstruct/tools/entity/DaggerEntity.java
@@ -7,6 +7,7 @@ import net.minecraft.world.World;
 
 import tconstruct.library.entity.ProjectileBase;
 import tconstruct.library.tools.*;
+import tconstruct.util.config.PHConstruct;
 
 public class DaggerEntity extends ProjectileBase {
 
@@ -58,7 +59,8 @@ public class DaggerEntity extends ProjectileBase {
                 returnStack,
                 (EntityPlayer) shootingEntity,
                 movingobjectposition.entityHit,
-                (ToolCore) returnStack.getItem());
+                (ToolCore) returnStack.getItem(),
+                PHConstruct.daggerThrowMultiplier);
         // super.onHitEntity(movingobjectposition);
     }
 

--- a/src/main/java/tconstruct/tools/entity/FancyEntityItem.java
+++ b/src/main/java/tconstruct/tools/entity/FancyEntityItem.java
@@ -6,12 +6,16 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 
+import tconstruct.util.config.PHConstruct;
+
 public class FancyEntityItem extends EntityItem {
 
     public FancyEntityItem(World par1World, double par2, double par4, double par6) {
         super(par1World, par2, par4, par6);
-        this.isImmuneToFire = true;
-        this.lifespan = 72000;
+        if (PHConstruct.indestructible) {
+            this.isImmuneToFire = true;
+            this.lifespan = 72000;
+        }
     }
 
     public FancyEntityItem(World par1World, double par2, double par4, double par6, ItemStack par8ItemStack) {
@@ -23,8 +27,10 @@ public class FancyEntityItem extends EntityItem {
 
     public FancyEntityItem(World par1World) {
         super(par1World);
-        this.isImmuneToFire = true;
-        this.lifespan = 72000;
+        if (PHConstruct.indestructible) {
+            this.isImmuneToFire = true;
+            this.lifespan = 72000;
+        }
     }
 
     public FancyEntityItem(World world, Entity original, ItemStack stack) {
@@ -37,6 +43,11 @@ public class FancyEntityItem extends EntityItem {
     }
 
     public boolean attackEntityFrom(DamageSource par1DamageSource, float par2) {
-        return par1DamageSource.getDamageType().equals("outOfWorld");
+        if (PHConstruct.indestructible) {
+            if (par1DamageSource.getDamageType().equals("outOfWorld")) return true;
+            return false;
+        } else {
+            return super.attackEntityFrom(par1DamageSource, par2);
+        }
     }
 }

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -71,10 +71,14 @@ public class PHConstruct {
                 "Difficulty Changes",
                 "Add alternative recipe for bolt parts: arrowhead + toolrod in a crafting grid",
                 false).getBoolean(false);
-        indestructible = config.get("Difficulty Changes", "Dropped tools are indestructible", false).getBoolean(false);
-        globalDespawn = config.get("Difficulty Changes", "Global item despawn time", 18000).getInt(18000);
-        dropCanisters = config.get("Difficulty Changes", "Drop heart canisters on death", true).getBoolean(true);
-        daggerThrowMultiplier = config.get("Difficulty Changes", "Thrown dagger output multiplier", 3).getDouble(3);
+        indestructible = config.get("Difficulty Changes", "Dropped tools are indestructible", true).getBoolean(true);
+        globalDespawn = config.get(
+                "Difficulty Changes",
+                "Global item despawn time",
+                0,
+                "Changes the despawn time of all items, 0 is vanilla behavior").getInt(0);
+        dropCanisters = config.get("Difficulty Changes", "Drop heart canisters on death", false).getBoolean(false);
+        daggerThrowMultiplier = config.get("Difficulty Changes", "Thrown dagger output multiplier", 1).getDouble(1);
 
         naturalSlimeSpawn = config.get("Mobs", "Blue Slime spawn chance", 1, "Set to 0 to disable").getInt(1);
 

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -71,8 +71,9 @@ public class PHConstruct {
                 "Difficulty Changes",
                 "Add alternative recipe for bolt parts: arrowhead + toolrod in a crafting grid",
                 false).getBoolean(false);
-        indestructible = config.get("Difficulty Changes", "Dropped tools are indestructible", true).getBoolean(true);
-        globalDespawn = config.get("Difficulty Changes", "Global item despawn time", 6000).getInt(6000);
+        indestructible = config.get("Difficulty Changes", "Dropped tools are indestructible", false).getBoolean(false);
+        globalDespawn = config.get("Difficulty Changes", "Global item despawn time", 18000).getInt(18000);
+        dropCanisters = config.get("Difficulty Changes", "Drop heart canisters on death", true).getBoolean(true);
 
         naturalSlimeSpawn = config.get("Mobs", "Blue Slime spawn chance", 1, "Set to 0 to disable").getInt(1);
 
@@ -431,6 +432,7 @@ public class PHConstruct {
     public static boolean alternativeBoltRecipe;
     public static boolean indestructible;
     public static int globalDespawn;
+    public static boolean dropCanisters;
 
     // Smeltery Output Modification
     public static double ingotsPerOre;

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -74,6 +74,7 @@ public class PHConstruct {
         indestructible = config.get("Difficulty Changes", "Dropped tools are indestructible", false).getBoolean(false);
         globalDespawn = config.get("Difficulty Changes", "Global item despawn time", 18000).getInt(18000);
         dropCanisters = config.get("Difficulty Changes", "Drop heart canisters on death", true).getBoolean(true);
+        daggerThrowMultiplier = config.get("Difficulty Changes", "Thrown dagger output multiplier", 3).getDouble(3);
 
         naturalSlimeSpawn = config.get("Mobs", "Blue Slime spawn chance", 1, "Set to 0 to disable").getInt(1);
 
@@ -433,6 +434,7 @@ public class PHConstruct {
     public static boolean indestructible;
     public static int globalDespawn;
     public static boolean dropCanisters;
+    public static double daggerThrowMultiplier;
 
     // Smeltery Output Modification
     public static double ingotsPerOre;

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -71,6 +71,8 @@ public class PHConstruct {
                 "Difficulty Changes",
                 "Add alternative recipe for bolt parts: arrowhead + toolrod in a crafting grid",
                 false).getBoolean(false);
+        indestructible = config.get("Difficulty Changes", "Dropped tools are indestructible", true).getBoolean(true);
+        globalDespawn = config.get("Difficulty Changes", "Global item despawn time", 6000).getInt(6000);
 
         naturalSlimeSpawn = config.get("Mobs", "Blue Slime spawn chance", 1, "Set to 0 to disable").getInt(1);
 
@@ -427,6 +429,8 @@ public class PHConstruct {
     public static boolean miningLevelIncrease;
     public static boolean denyMattock;
     public static boolean alternativeBoltRecipe;
+    public static boolean indestructible;
+    public static int globalDespawn;
 
     // Smeltery Output Modification
     public static double ingotsPerOre;

--- a/src/main/java/tconstruct/weaponry/weapons/Javelin.java
+++ b/src/main/java/tconstruct/weaponry/weapons/Javelin.java
@@ -25,7 +25,7 @@ public class Javelin extends AmmoWeapon {
     @Override
     public boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity entity) {
         // javelin is the only throwing/ammo weapon that hurts on leftclicking
-        return AbilityHelper.onLeftClickEntity(stack, player, entity, this, 0);
+        return AbilityHelper.onLeftClickEntity(stack, player, entity, this);
     }
 
     @Override


### PR DESCRIPTION
adds the config options from the [tinkered constructor](https://www.curseforge.com/minecraft/mc-mods/tinkered-constructor) fork of tinkers construct, including.

- dropping heart canisters on death
- disabling tinker tools being indestructible
- changing the global item despawn time
- changing the tinkers dagger damage output with a multiplier

all config options are set to function like vanilla by default.