### PR TITLE
fix smeltery tps lag by clearing drain array before structure check

### DIFF
--- a/src/main/java/tconstruct/smeltery/logic/CastingBlockLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/CastingBlockLogic.java
@@ -373,7 +373,10 @@ public abstract class CastingBlockLogic extends InventoryLogic implements IFluid
         tick++;
         if (tick % 20 == 0) {
             tick = 0;
-            if (needsUpdate) worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+            if (needsUpdate) {
+                needsUpdate = false;
+                worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+            }
         }
     }
 

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -794,6 +794,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
     public boolean checkSameLevel(int x, int y, int z, int[] sides) {
         lavaTanks.clear();
+        drains.clear();
         boolean check = checkBricksOnLevel(x, y, z, sides);
         return check && lavaTanks.size() > 0;
     }


### PR DESCRIPTION
Smeltery structure check fills internal arrayList of drains and lava tanks
without clearing drains beforehand they get filled forever and cause lag due to thousands of block updates
this pr fixes that(and also includes mitch's old unpushed changes)