### PR TITLE
fix smeltery acceleration and comparator output

### DIFF
--- a/src/main/java/tconstruct/smeltery/logic/SmelteryDrainLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryDrainLogic.java
@@ -169,6 +169,7 @@ public class SmelteryDrainLogic extends MultiServantLogic implements IFluidHandl
         if (smeltery == null) return 0;
 
         if (smeltery.maxLiquid == 0) return 0;
-        return 15 * smeltery.currentLiquid / smeltery.maxLiquid;
+
+        return MathHelper.ceiling_float_int(15f * smeltery.currentLiquid / smeltery.maxLiquid);
     }
 }

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -614,7 +614,6 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     @Override
     public void markDirty() {
         updateTemperatures();
-        updateEntity();
 
         super.markDirty();
         needsUpdate = true;


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12867
markDirty gets called when you insert items in the smeltery. You could accelerate smelting time by spam inputting items using mouse wheel, since markDirty also updated the smeltery for no reason.

Also fixes drain comparator output being 0 even with fluid inside smeltery. Small values used to be truncated and are now rounded up instead.