### PR TITLE
fix crash when opening stencil table with cast

### DIFF
--- a/src/main/java/tconstruct/tools/gui/StencilTableGui.java
+++ b/src/main/java/tconstruct/tools/gui/StencilTableGui.java
@@ -116,15 +116,19 @@ public class StencilTableGui extends GuiContainer implements INEIGuiHandler {
 
         // get the correct setting :I
         ItemStack stack;
-        if (logic.getStackInSlot(1) != null) {
-            activeButton = StencilBuilder.getId(logic.getStackInSlot(1));
-            setActiveButton(activeButton);
+        ItemStack setting = logic.getStackInSlot(1);
+        int currentSetting = setting != null ? StencilBuilder.getId(setting) : -1;
+        if (currentSetting >= 0) {
+            setActiveButton(currentSetting);
             stack = StencilBuilder
                     .getStencil(((GuiButtonStencil) this.buttonList.get(activeButton)).element.stencilIndex);
         } else stack = null;
 
-        logic.setSelectedPattern(stack);
-        updateServer(stack);
+        // only set valid patterns
+        if (stack != null) {
+            logic.setSelectedPattern(stack);
+            updateServer(stack);
+        }
     }
 
     @Override

--- a/src/main/java/tconstruct/weaponry/WeaponryClientProxy.java
+++ b/src/main/java/tconstruct/weaponry/WeaponryClientProxy.java
@@ -113,12 +113,12 @@ public class WeaponryClientProxy extends WeaponryCommonProxy {
         TConstructClientRegistry.addStencilButton2(0, 0, -1, null, null);
         TConstructClientRegistry.addStencilButton2(0, 0, -1, null, null);
 
-        TConstructClientRegistry.addStencilButton2(3, 4, 27, Reference.RESOURCE, tex); // bow limb
         TConstructClientRegistry.addStencilButton2(10, 3, 23, Reference.RESOURCE, tex); // bowstring
+        TConstructClientRegistry.addStencilButton2(0, 4, 24, Reference.RESOURCE, tex); // shuriken
         TConstructClientRegistry.addStencilButton2(1, 4, 25, Reference.RESOURCE, tex); // crossbow limb
         TConstructClientRegistry.addStencilButton2(2, 4, 26, Reference.RESOURCE, tex); // crossbow body
 
-        TConstructClientRegistry.addStencilButton2(0, 4, 24, Reference.RESOURCE, tex); // shuriken
+        TConstructClientRegistry.addStencilButton2(3, 4, 27, Reference.RESOURCE, tex); // bow limb
         // TConstructClientRegistry.addStencilButton2(4, 4, index, Reference.RESOURCE, "textures/gui/icons.png"); //
         // bolt
 


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13542
added guards before setActiveButton and setSelectedPattern if item is not a valid stencil
Also noticed tinkers weaponry buttons were added in wrong order which made setActiveButton set the wrong button