### PR TITLE
Fix health bar renderer

### DIFF
--- a/src/main/java/tconstruct/armor/ArmorProxyClient.java
+++ b/src/main/java/tconstruct/armor/ArmorProxyClient.java
@@ -1,8 +1,11 @@
 package tconstruct.armor;
 
+import static net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType.HEALTH;
+
 import java.util.Random;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.Tessellator;
@@ -25,6 +28,8 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 import net.minecraftforge.common.MinecraftForge;
+
+import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
@@ -233,7 +238,6 @@ public class ArmorProxyClient extends ArmorProxyCommon {
     Minecraft mc = Minecraft.getMinecraft();
 
     private static final ResourceLocation hearts = new ResourceLocation("tinker", "textures/gui/newhearts.png");
-    private static final ResourceLocation icons = new ResourceLocation("textures/gui/icons.png");
     // public static int left_height = 39;
     // public static int right_height = 39;
     Random rand = new Random();
@@ -274,6 +278,9 @@ public class ArmorProxyClient extends ArmorProxyCommon {
             // with a GUI mod (thanks Vazkii!)
             return;
         }
+
+        mc.mcProfiler.startSection("health");
+        GL11.glEnable(GL11.GL_BLEND);
 
         int scaledWidth = event.resolution.getScaledWidth();
         int scaledHeight = event.resolution.getScaledHeight();
@@ -369,11 +376,13 @@ public class ArmorProxyClient extends ArmorProxyCommon {
             }
         }
 
-        this.mc.getTextureManager().bindTexture(icons);
+        this.mc.getTextureManager().bindTexture(Gui.icons);
         GuiIngameForge.left_height += 10;
         if (absorb > 0) GuiIngameForge.left_height += 10;
-
+        GL11.glDisable(GL11.GL_BLEND);
+        mc.mcProfiler.endSection();
         event.setCanceled(true);
+        MinecraftForge.EVENT_BUS.post(new RenderGameOverlayEvent.Post(event, HEALTH));
     }
 
     public void drawTexturedModalRect(int par1, int par2, int par3, int par4, int par5, int par6) {

--- a/src/main/java/tconstruct/armor/ArmorProxyClient.java
+++ b/src/main/java/tconstruct/armor/ArmorProxyClient.java
@@ -445,17 +445,11 @@ public class ArmorProxyClient extends ArmorProxyCommon {
     }
 
     void renderArmorExtras(RenderPlayerEvent.SetArmorModel event) {
-        float partialTick = event.partialRenderTick;
 
         EntityPlayer player = event.entityPlayer;
-
         // todo: synchronize extra armor with other clients. Until then, only draw locally
         if (player != Minecraft.getMinecraft().thePlayer) return;
-
-        float posX = (float) (player.lastTickPosX + (player.posX - player.lastTickPosX) * partialTick);
-        float posY = (float) (player.lastTickPosY + (player.posY - player.lastTickPosY) * partialTick);
-        float posZ = (float) (player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * partialTick);
-
+        float partialTick = event.partialRenderTick;
         float yawOffset = this.interpolateRotation(player.prevRenderYawOffset, player.renderYawOffset, partialTick);
         float yawRotation = this.interpolateRotation(player.prevRotationYawHead, player.rotationYawHead, partialTick);
         float pitch;

--- a/src/main/java/tconstruct/client/HealthBarRenderer.java
+++ b/src/main/java/tconstruct/client/HealthBarRenderer.java
@@ -155,6 +155,8 @@ public class HealthBarRenderer extends Gui {
             // Render tinkers' hearts
             mc.getTextureManager().bindTexture(TINKER_HEARTS);
             for (int i = Math.max(0, health / 20 - 2); i < health / 20; i++) {
+                // uncomment the line below to help with debugging
+                // yBasePos -=20;
                 final int heartIndexMax = Math.min(10, (health - 20 * (i + 1)) / 2);
                 for (int j = 0; j < heartIndexMax; j++) {
                     int y = 0;

--- a/src/main/java/tconstruct/client/HealthBarRenderer.java
+++ b/src/main/java/tconstruct/client/HealthBarRenderer.java
@@ -154,13 +154,15 @@ public class HealthBarRenderer extends Gui {
         if (health > 20) {
             // Render tinkers' hearts
             mc.getTextureManager().bindTexture(TINKER_HEARTS);
-            for (int i = 0; i < health / 20; i++) {
+            for (int i = Math.max(0, health / 20 - 2); i < health / 20; i++) {
                 final int heartIndexMax = Math.min(10, (health - 20 * (i + 1)) / 2);
                 for (int j = 0; j < heartIndexMax; j++) {
                     int y = 0;
                     if (j == regen) y -= 2;
-                    // full heart texture
-                    this.drawTexturedModalRect(xBasePos + 8 * j, yBasePos + y, 18 * i, tinkerTextureY, 9, 9);
+                    if ((i + 1) * 20 + j * 2 + 21 >= health) {
+                        // full heart texture
+                        this.drawTexturedModalRect(xBasePos + 8 * j, yBasePos + y, 18 * i, tinkerTextureY, 9, 9);
+                    }
                 }
                 if (health % 2 == 1 && heartIndexMax < 10) {
                     int y = 0;

--- a/src/main/java/tconstruct/client/HealthBarRenderer.java
+++ b/src/main/java/tconstruct/client/HealthBarRenderer.java
@@ -150,29 +150,23 @@ public class HealthBarRenderer extends Gui {
             }
         }
 
-        // Extra hearts
-        mc.getTextureManager().bindTexture(TINKER_HEARTS);
-
-        for (int iter = 0; iter < health / 20; iter++) {
-            int renderHearts = (health - 20 * (iter + 1)) / 2;
-            if (renderHearts > 10) renderHearts = 10;
-            for (int i = 0; i < renderHearts; i++) {
-                int y = 0;
-                if (i == regen) y -= 2;
-                this.drawTexturedModalRect(xBasePos + 8 * i, yBasePos + y, 18 * iter, tinkerPotionOffset, 9, 9);
+        if (health > 20) {
+            // Render tinkers' hearts
+            mc.getTextureManager().bindTexture(TINKER_HEARTS);
+            for (int i = 0; i < health / 20; i++) {
+                final int renderHearts = Math.min(10, (health - 20 * (i + 1)) / 2);
+                for (int j = 0; j < renderHearts; j++) {
+                    int y = 0;
+                    if (j == regen) y -= 2;
+                    this.drawTexturedModalRect(xBasePos + 8 * j, yBasePos + y, 18 * i, tinkerTextureY, 9, 9);
+                }
+                if (health % 2 == 1 && renderHearts < 10) {
+                    this.drawTexturedModalRect(xBasePos + 8 * renderHearts, yBasePos, 9 + 18 * i, tinkerTextureY, 9, 9);
+                }
             }
-            if (health % 2 == 1 && renderHearts < 10) {
-                this.drawTexturedModalRect(
-                        xBasePos + 8 * renderHearts,
-                        yBasePos,
-                        9 + 18 * iter,
-                        tinkerPotionOffset,
-                        9,
-                        9);
-            }
+            mc.getTextureManager().bindTexture(icons);
         }
 
-        mc.getTextureManager().bindTexture(icons);
         GuiIngameForge.left_height += 10;
         if (absorb > 0) GuiIngameForge.left_height += 10;
         GL11.glDisable(GL11.GL_BLEND);

--- a/src/main/java/tconstruct/client/HealthBarRenderer.java
+++ b/src/main/java/tconstruct/client/HealthBarRenderer.java
@@ -155,14 +155,24 @@ public class HealthBarRenderer extends Gui {
             // Render tinkers' hearts
             mc.getTextureManager().bindTexture(TINKER_HEARTS);
             for (int i = 0; i < health / 20; i++) {
-                final int renderHearts = Math.min(10, (health - 20 * (i + 1)) / 2);
-                for (int j = 0; j < renderHearts; j++) {
+                final int heartIndexMax = Math.min(10, (health - 20 * (i + 1)) / 2);
+                for (int j = 0; j < heartIndexMax; j++) {
                     int y = 0;
                     if (j == regen) y -= 2;
-                    this.drawTexturedModalRect(xBasePos + 8 * j, yBasePos + y, 18 * i, tinkerTextureY, 9, 9); // full heart texture
+                    // full heart texture
+                    this.drawTexturedModalRect(xBasePos + 8 * j, yBasePos + y, 18 * i, tinkerTextureY, 9, 9);
                 }
-                if (health % 2 == 1 && renderHearts < 10) {
-                    this.drawTexturedModalRect(xBasePos + 8 * renderHearts, yBasePos, 9 + 18 * i, tinkerTextureY, 9, 9); // half heart texture
+                if (health % 2 == 1 && heartIndexMax < 10) {
+                    int y = 0;
+                    if (heartIndexMax == regen) y -= 2;
+                    // half heart texture
+                    this.drawTexturedModalRect(
+                            xBasePos + 8 * heartIndexMax,
+                            yBasePos + y,
+                            9 + 18 * i,
+                            tinkerTextureY,
+                            9,
+                            9);
                 }
             }
             mc.getTextureManager().bindTexture(icons);

--- a/src/main/java/tconstruct/client/HealthBarRenderer.java
+++ b/src/main/java/tconstruct/client/HealthBarRenderer.java
@@ -1,0 +1,185 @@
+package tconstruct.client;
+
+import static net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType.HEALTH;
+
+import java.util.Random;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.IAttributeInstance;
+import net.minecraft.potion.Potion;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.GuiIngameForge;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.common.MinecraftForge;
+
+import org.lwjgl.opengl.GL11;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+
+public class HealthBarRenderer extends Gui {
+
+    private static final boolean isRpghudLoaded = Loader.isModLoaded("rpghud");
+    private static final boolean isTukmc_vzLoaded = Loader.isModLoaded("tukmc_Vz");
+    private static final boolean isBorderlandsModLoaded = Loader.isModLoaded("borderlands");
+    private static final ResourceLocation TINKER_HEARTS = new ResourceLocation("tinker", "textures/gui/newhearts.png");
+    private static final Minecraft mc = Minecraft.getMinecraft();
+    private final Random rand = new Random();
+    private int updateCounter = 0;
+
+    @SubscribeEvent
+    public void onTick(TickEvent.ClientTickEvent event) {
+        if (event.phase == TickEvent.Phase.START) {
+            this.updateCounter++;
+        }
+    }
+
+    /* HUD */
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void renderHealthbar(RenderGameOverlayEvent.Pre event) {
+
+        if (event.type != RenderGameOverlayEvent.ElementType.HEALTH) {
+            return;
+        }
+
+        // uses different display, displays health correctly by itself.
+        if (isRpghudLoaded) {
+            return;
+        }
+
+        if (isTukmc_vzLoaded && !isBorderlandsModLoaded) {
+            // Loader check to avoid conflicting
+            // with a GUI mod (thanks Vazkii!)
+            return;
+        }
+
+        mc.mcProfiler.startSection("health");
+        GL11.glEnable(GL11.GL_BLEND);
+
+        int scaledWidth = event.resolution.getScaledWidth();
+        int scaledHeight = event.resolution.getScaledHeight();
+        int xBasePos = scaledWidth / 2 - 91;
+        int yBasePos = scaledHeight - 39;
+
+        boolean highlight = mc.thePlayer.hurtResistantTime / 3 % 2 == 1;
+
+        if (mc.thePlayer.hurtResistantTime < 10) {
+            highlight = false;
+        }
+
+        final IAttributeInstance attrMaxHealth = mc.thePlayer.getEntityAttribute(SharedMonsterAttributes.maxHealth);
+        final int health = MathHelper.ceiling_float_int(mc.thePlayer.getHealth());
+        final int healthLast = MathHelper.ceiling_float_int(mc.thePlayer.prevHealth);
+        float healthMax = (float) attrMaxHealth.getAttributeValue();
+        if (healthMax > 20F) healthMax = 20F;
+        float absorb = mc.thePlayer.getAbsorptionAmount();
+
+        final int healthRows = MathHelper.ceiling_float_int((healthMax + absorb) / 2.0F / 10.0F);
+        final int rowHeight = Math.max(10 - (healthRows - 2), 3);
+
+        this.rand.setSeed(updateCounter * 312871L);
+
+        int left = scaledWidth / 2 - 91;
+        int top = scaledHeight - GuiIngameForge.left_height;
+
+        if (!GuiIngameForge.renderExperiance) {
+            top += 7;
+            yBasePos += 7;
+        }
+
+        int regen = -1;
+        if (mc.thePlayer.isPotionActive(Potion.regeneration)) {
+            regen = updateCounter % 25;
+        }
+
+        final int TOP;
+        int tinkerPotionOffset = 0;
+        if (mc.theWorld.getWorldInfo().isHardcoreModeEnabled()) {
+            TOP = 9 * 5;
+            tinkerPotionOffset += 27;
+        } else {
+            TOP = 0;
+        }
+        final int BACKGROUND = (highlight ? 25 : 16);
+        int MARGIN = 16;
+        if (mc.thePlayer.isPotionActive(Potion.poison)) {
+            MARGIN += 36;
+            tinkerPotionOffset = 9;
+        } else if (mc.thePlayer.isPotionActive(Potion.wither)) {
+            MARGIN += 72;
+            tinkerPotionOffset = 18;
+        }
+        float absorbRemaining = absorb;
+
+        for (int i = MathHelper.ceiling_float_int((healthMax + absorb) / 2.0F) - 1; i >= 0; --i) {
+            final int row = MathHelper.ceiling_float_int((float) (i + 1) / 10.0F) - 1;
+            int x = left + i % 10 * 8;
+            int y = top - row * rowHeight;
+
+            if (health <= 4) y += rand.nextInt(2);
+            if (i == regen) y -= 2;
+
+            this.drawTexturedModalRect(x, y, BACKGROUND, TOP, 9, 9);
+
+            if (highlight) {
+                if (i * 2 + 1 < healthLast) {
+                    this.drawTexturedModalRect(x, y, MARGIN + 54, TOP, 9, 9); // 6
+                } else if (i * 2 + 1 == healthLast) {
+                    this.drawTexturedModalRect(x, y, MARGIN + 63, TOP, 9, 9); // 7
+                }
+            }
+
+            if (absorbRemaining > 0.0F) {
+                if (absorbRemaining == absorb && absorb % 2.0F == 1.0F) {
+                    this.drawTexturedModalRect(x, y, MARGIN + 153, TOP, 9, 9); // 17
+                } else {
+                    this.drawTexturedModalRect(x, y, MARGIN + 144, TOP, 9, 9); // 16
+                }
+                absorbRemaining -= 2.0F;
+            } else {
+                if (i * 2 + 1 < health) {
+                    this.drawTexturedModalRect(x, y, MARGIN + 36, TOP, 9, 9); // 4
+                } else if (i * 2 + 1 == health) {
+                    this.drawTexturedModalRect(x, y, MARGIN + 45, TOP, 9, 9); // 5
+                }
+            }
+        }
+
+        // Extra hearts
+        mc.getTextureManager().bindTexture(TINKER_HEARTS);
+
+        for (int iter = 0; iter < health / 20; iter++) {
+            int renderHearts = (health - 20 * (iter + 1)) / 2;
+            if (renderHearts > 10) renderHearts = 10;
+            for (int i = 0; i < renderHearts; i++) {
+                int y = 0;
+                if (i == regen) y -= 2;
+                this.drawTexturedModalRect(xBasePos + 8 * i, yBasePos + y, 18 * iter, tinkerPotionOffset, 9, 9);
+            }
+            if (health % 2 == 1 && renderHearts < 10) {
+                this.drawTexturedModalRect(
+                        xBasePos + 8 * renderHearts,
+                        yBasePos,
+                        9 + 18 * iter,
+                        tinkerPotionOffset,
+                        9,
+                        9);
+            }
+        }
+
+        mc.getTextureManager().bindTexture(icons);
+        GuiIngameForge.left_height += 10;
+        if (absorb > 0) GuiIngameForge.left_height += 10;
+        GL11.glDisable(GL11.GL_BLEND);
+        mc.mcProfiler.endSection();
+        event.setCanceled(true);
+        MinecraftForge.EVENT_BUS.post(new RenderGameOverlayEvent.Post(event, HEALTH));
+
+    }
+
+}

--- a/src/main/java/tconstruct/client/HealthBarRenderer.java
+++ b/src/main/java/tconstruct/client/HealthBarRenderer.java
@@ -34,7 +34,7 @@ public class HealthBarRenderer extends Gui {
 
     @SubscribeEvent
     public void onTick(TickEvent.ClientTickEvent event) {
-        if (event.phase == TickEvent.Phase.START) {
+        if (event.phase == TickEvent.Phase.START && !mc.isGamePaused()) {
             this.updateCounter++;
         }
     }


### PR DESCRIPTION
Tinkers constructs completely overwrites the health bar rendering and there were multiple bugs with it. Notably it was drawing all of the hearts that your character has on top of each other even though you can only see the 10 hearts at the very top, costing performance for nothing.

In this pr I :

- add some code that has been forgotten when copying and overriding the vanilla renderHealth method
- create dedicated class HealthBarRenderer extending Gui to stop copy-pasting certain vanilla methods
- fix renegeration hearts moving when the game is paused
- only bind tinkers hearts textures if it's actually going to draw tinkers' hearts (helth above 20)
- stop drawing vanilla hearts when they are hidden by tinkers' heart being drawn on top
- fix tinker's half heart not moving with regeneration
- fix drawing all tinkers' hearts on top of each others, and now only draw the top most hearts