### PR TITLE
fix health bar not being shifted up by DualHotbar

### DIFF
--- a/src/main/java/tconstruct/client/HealthBarRenderer.java
+++ b/src/main/java/tconstruct/client/HealthBarRenderer.java
@@ -40,7 +40,7 @@ public class HealthBarRenderer extends Gui {
     }
 
     /* HUD */
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    @SubscribeEvent(priority = EventPriority.HIGH) // Not highest for DualHotbar compatibility
     public void renderHealthbar(RenderGameOverlayEvent.Pre event) {
 
         if (event.type != RenderGameOverlayEvent.ElementType.HEALTH) {


### PR DESCRIPTION
weakens EventPriority (raised in #97) of HealthBarRenderer to High to allow DualHotbar to shift the renderer up again
[before](https://github.com/GTNewHorizons/TinkersConstruct/assets/27380203/f1fd3409-0160-4309-be86-af26a2759762) & [after](https://github.com/GTNewHorizons/TinkersConstruct/assets/27380203/43756be2-9a7e-40ba-ae9e-a83aa304f84f)

