### PR TITLE
Seared Tank QOL

### DIFF
--- a/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
@@ -150,8 +150,9 @@ public class LavaTankBlock extends BlockContainer {
                 int amount = logic.fill(ForgeDirection.UNKNOWN, liquid, false);
                 if (amount == liquid.amount) {
                     logic.fill(ForgeDirection.UNKNOWN, liquid, true);
-                    if (!entityplayer.capabilities.isCreativeMode)
-                        replaceHeldItem(entityplayer, getEmptyContainer(entityplayer.inventory.getCurrentItem()));
+                    if (!entityplayer.capabilities.isCreativeMode) {
+                        replaceHeldItem(entityplayer, getEmptyContainer(current));
+                    }
 
                     // update
                     entityplayer.inventoryContainer.detectAndSendChanges();

--- a/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
@@ -151,7 +151,7 @@ public class LavaTankBlock extends BlockContainer {
                 if (amount == liquid.amount) {
                     logic.fill(ForgeDirection.UNKNOWN, liquid, true);
                     if (!entityplayer.capabilities.isCreativeMode) {
-                        replaceHeldItem(entityplayer, getEmptyContainer(current));
+                        replaceHeldItem(entityplayer, FluidContainerRegistry.drainFluidContainer(current));
                     }
 
                     // update
@@ -188,14 +188,6 @@ public class LavaTankBlock extends BlockContainer {
         }
 
         return false;
-    }
-
-    private static ItemStack getEmptyContainer(ItemStack stack) {
-        Item item = stack.getItem();
-        if (item != null && item.hasContainerItem(stack)) return item.getContainerItem(stack);
-        else if (FluidContainerRegistry.isFilledContainer(stack))
-            return FluidContainerRegistry.drainFluidContainer(stack);
-        else return null;
     }
 
     /**

--- a/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
@@ -216,6 +216,12 @@ public class LavaTankBlock extends BlockContainer {
         }
     }
 
+    /**
+     * This was probably not meant to be public and should ideally be removed. It's a direct copy of code found in
+     * buildcraft.core.lib.inventory.InvUtils.
+     * <p>
+     * In any case it is no longer useful here.
+     */
     public static ItemStack consumeItem(ItemStack stack) {
         if (stack.stackSize == 1) {
             if (stack.getItem().hasContainerItem()) return stack.getItem().getContainerItem(stack);

--- a/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
@@ -161,7 +161,7 @@ public class LavaTankBlock extends BlockContainer {
                 return true;
             }
             // taking liquit out of the tank
-            else if (FluidContainerRegistry.isBucket(current)) {
+            else if (FluidContainerRegistry.isContainer(current)) {
                 FluidTankInfo[] tanks = logic.getTankInfo(ForgeDirection.UNKNOWN);
                 FluidStack fillFluid = tanks[0].fluid; // getFluid();
                 if (!world.isRemote) {


### PR DESCRIPTION
This PR is intended to make the Seared Tank behave like any other fluid container block when it comes to interacting with fluid container items when right-clicked.

# Fixes
- Clay Buckets don't splash water clientside when filling the tank.
- Bottles, Cells and other non-Bucket containers do not get consumed when filling the tank and are instead replaced by their empty container.

# Changes
- Any container which can fill the tank can now drain it, this includes Clay Buckets, Cells and Bottles.

# Not changed
- There is a `public static ItemStack consumeItem(ItemStack stack)` method on LavaTankBlock which now isn't used anywhere, is copy-pasted from `buildcraft.core.lib.inventory.InvUtils` and probably wasn't meant to be public. I've kept it to avoid a public API change. I'd rather remove it or at least mark it as deprecated.

# Media

## Before
![before](https://github.com/GTNewHorizons/TinkersConstruct/assets/5321549/3b71fa2e-ed51-4fb1-b062-34865e5aee0c)

## After
![after](https://github.com/GTNewHorizons/TinkersConstruct/assets/5321549/be6674b4-4e27-45a1-9e73-4af2afa24792)
