### PR TITLE
Delegate manuals to dreamcraft

### DIFF
--- a/src/main/java/tconstruct/client/TProxyClient.java
+++ b/src/main/java/tconstruct/client/TProxyClient.java
@@ -16,6 +16,7 @@ import net.minecraft.util.ResourceLocation;
 
 import org.w3c.dom.Document;
 
+import cpw.mods.fml.common.Loader;
 import mantle.client.SmallFontRenderer;
 import mantle.lib.client.MantleClientRegistry;
 import tconstruct.TConstruct;
@@ -57,6 +58,15 @@ public class TProxyClient extends TProxyCommon {
     public static ManualInfo manualData;
 
     public void readManuals() {
+        initManualIcons();
+        initManualRecipes();
+        initManualPages();
+        if (!Loader.isModLoaded("dreamcraft")) {
+            readTinkersConstructManuals();
+        }
+    }
+
+    private void readTinkersConstructManuals() {
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
         String CurrentLanguage = Minecraft.getMinecraft().getLanguageManager().getCurrentLanguage().getLanguageCode();
 
@@ -73,9 +83,6 @@ public class TProxyClient extends TProxyCommon {
         weaponry = weaponry_cl != null ? weaponry_cl
                 : readManual("/assets/tinker/manuals/en_US/weaponry.xml", dbFactory);
 
-        initManualIcons();
-        initManualRecipes();
-        initManualPages();
         manualData = new ManualInfo();
     }
 

--- a/src/main/java/tconstruct/tools/items/Manual.java
+++ b/src/main/java/tconstruct/tools/items/Manual.java
@@ -1,6 +1,7 @@
 package tconstruct.tools.items;
 
 import java.util.List;
+import java.util.Objects;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -41,22 +42,25 @@ public class Manual extends CraftingItem {
 
     @SideOnly(Side.CLIENT)
     public void openBook(ItemStack stack, World world, EntityPlayer player) {
-        player.openGui(TConstruct.instance, mantle.client.MProxyClient.manualGuiID, world, 0, 0, 0);
-        FMLClientHandler.instance().displayGuiScreen(player, new GuiManual(stack, getData(stack)));
+        BookData data = BookDataStore.getBookfromName(TConstruct.modID, getBookName(stack.getItemDamage()));
+        if (Objects.nonNull(data)) {
+            player.openGui(TConstruct.instance, mantle.client.MProxyClient.manualGuiID, world, 0, 0, 0);
+            FMLClientHandler.instance().displayGuiScreen(player, new GuiManual(stack, data));
+        }
     }
 
-    private BookData getData(ItemStack stack) {
-        switch (stack.getItemDamage()) {
+    private static String getBookName(int bookItemDamage) {
+        switch (bookItemDamage) {
             case 0:
-                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.beginner");
+                return "tconstruct.manual.beginner";
             case 1:
-                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.toolstation");
+                return "tconstruct.manual.toolstation";
             case 2:
-                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.smeltery");
+                return "tconstruct.manual.smeltery";
             case 4:
-                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.weaponry");
+                return "tconstruct.manual.weaponry";
             default:
-                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.diary");
+                return "tconstruct.manual.diary";
         }
     }
 

--- a/src/main/java/tconstruct/tools/items/Manual.java
+++ b/src/main/java/tconstruct/tools/items/Manual.java
@@ -11,11 +11,11 @@ import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import mantle.books.BookData;
+import mantle.books.BookDataStore;
 import mantle.client.gui.GuiManual;
 import mantle.items.abstracts.CraftingItem;
 import tconstruct.TConstruct;
 import tconstruct.achievements.TAchievements;
-import tconstruct.client.TProxyClient;
 import tconstruct.library.TConstructRegistry;
 
 public class Manual extends CraftingItem {
@@ -48,15 +48,15 @@ public class Manual extends CraftingItem {
     private BookData getData(ItemStack stack) {
         switch (stack.getItemDamage()) {
             case 0:
-                return TProxyClient.manualData.beginner;
+                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.beginner");
             case 1:
-                return TProxyClient.manualData.toolStation;
+                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.toolstation");
             case 2:
-                return TProxyClient.manualData.smeltery;
+                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.smeltery");
             case 4:
-                return TProxyClient.manualData.weaponry;
+                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.weaponry");
             default:
-                return TProxyClient.manualData.diary;
+                return BookDataStore.getBookfromName(TConstruct.modID, "tconstruct.manual.diary");
         }
     }
 

--- a/src/main/java/tconstruct/tools/items/ManualInfo.java
+++ b/src/main/java/tconstruct/tools/items/ManualInfo.java
@@ -9,54 +9,43 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import mantle.books.BookData;
 import mantle.books.BookDataStore;
+import tconstruct.TConstruct;
 import tconstruct.client.TProxyClient;
 
+/**
+ * This class is now just a constructor with side effects, so a glorified method call. TODO: Clean up when breaking API
+ * change is deemed acceptable.
+ */
 public class ManualInfo {
-    // static String[] name = new String[] { "beginner", "toolstation", "smeltery", "diary" };
-    // static String[] textureName = new String[] { "tinkerbook_diary", "tinkerbook_toolstation",
-    // "tinkerbook_smeltery", "tinkerbook_blue" };
-
-    BookData beginner = new BookData();
-    BookData toolStation = new BookData();
-    BookData smeltery = new BookData();
-    BookData diary = new BookData();
-    BookData weaponry = new BookData();
-
-    /*
-     * diary = readManual("/assets/tinker/manuals/diary.xml", dbFactory); volume1 =
-     * readManual("/assets/tinker/manuals/firstday.xml", dbFactory); volume2 =
-     * readManual("/assets/tinker/manuals/materials.xml", dbFactory); smelter =
-     * readManual("/assets/tinker/manuals/smeltery.xml", dbFactory);
-     */
 
     public ManualInfo() {
         Side side = FMLCommonHandler.instance().getEffectiveSide();
-        beginner = initManual(
-                beginner,
+        initManual(
+                new BookData(),
                 "tconstruct.manual.beginner",
                 "\u00a7o" + StatCollector.translateToLocal("manual1.tooltip"),
                 side == Side.CLIENT ? TProxyClient.volume1 : null,
                 "tinker:tinkerbook_diary");
-        toolStation = initManual(
-                toolStation,
+        initManual(
+                new BookData(),
                 "tconstruct.manual.toolstation",
                 "\u00a7o" + StatCollector.translateToLocal("manual2.tooltip"),
                 side == Side.CLIENT ? TProxyClient.volume2 : null,
                 "tinker:tinkerbook_toolstation");
-        smeltery = initManual(
-                smeltery,
+        initManual(
+                new BookData(),
                 "tconstruct.manual.smeltery",
                 "\u00a7o" + StatCollector.translateToLocal("manual3.tooltip"),
                 side == Side.CLIENT ? TProxyClient.smelter : null,
                 "tinker:tinkerbook_smeltery");
-        diary = initManual(
-                diary,
+        initManual(
+                new BookData(),
                 "tconstruct.manual.diary",
                 "\u00a7o" + StatCollector.translateToLocal("manual4.tooltip"),
                 side == Side.CLIENT ? TProxyClient.diary : null,
                 "tinker:tinkerbook_blue");
-        weaponry = initManual(
-                weaponry,
+        initManual(
+                new BookData(),
                 "tconstruct.manual.weaponry",
                 "\u00a7o" + StatCollector.translateToLocal("manual5.tooltip"),
                 side == Side.CLIENT ? TProxyClient.weaponry : null,
@@ -64,10 +53,9 @@ public class ManualInfo {
     }
 
     public BookData initManual(BookData data, String unlocName, String toolTip, Document xmlDoc, String itemImage) {
-        // proxy.readManuals();
         data.unlocalizedName = unlocName;
         data.toolTip = unlocName;
-        data.modID = "TConstruct";
+        data.modID = TConstruct.modID;
         data.itemImage = new ResourceLocation(data.modID, itemImage);
         data.doc = xmlDoc;
         BookDataStore.addBook(data);


### PR DESCRIPTION
Don't load any manuals from Tinker's Construct if dreamcraft is loaded.

This PR needs to be merged for https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/797 to fully take effect.