### PR TITLE
Allow stacks of essence berries to be consumed at once

### DIFF
--- a/src/main/java/tconstruct/world/items/OreBerries.java
+++ b/src/main/java/tconstruct/world/items/OreBerries.java
@@ -52,14 +52,21 @@ public class OreBerries extends CraftingItem {
     @Override
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
         if (stack.getItemDamage() == 5) {
-            EntityXPOrb entity = new EntityXPOrb(
-                    world,
-                    player.posX,
-                    player.posY + 1,
-                    player.posZ,
-                    itemRand.nextInt(14) + 6);
-            spawnEntity(player.posX, player.posY + 1, player.posZ, entity, world, player);
-            if (!player.capabilities.isCreativeMode) stack.stackSize--;
+            if (!player.isSneaking()) {
+                EntityXPOrb entity = new EntityXPOrb(
+                        world,
+                        player.posX,
+                        player.posY + 1,
+                        player.posZ,
+                        itemRand.nextInt(14) + 6);
+                spawnEntity(player.posX, player.posY + 1, player.posZ, entity, world, player);
+                if (!player.capabilities.isCreativeMode) stack.stackSize--;
+            } else {
+                for (int i = stack.stackSize; i > 0; i--) {
+                    player.addExperience(itemRand.nextInt(14) + 6);
+                }
+                if (!player.capabilities.isCreativeMode) stack.stackSize = 0;
+            }
         }
         return stack;
     }

--- a/src/main/java/tconstruct/world/items/OreBerries.java
+++ b/src/main/java/tconstruct/world/items/OreBerries.java
@@ -62,9 +62,11 @@ public class OreBerries extends CraftingItem {
                 spawnEntity(player.posX, player.posY + 1, player.posZ, entity, world, player);
                 if (!player.capabilities.isCreativeMode) stack.stackSize--;
             } else {
+                int xpToAdd = 0;
                 for (int i = stack.stackSize; i > 0; i--) {
-                    player.addExperience(itemRand.nextInt(14) + 6);
+                    xpToAdd += itemRand.nextInt(14) + 6;
                 }
+                player.addExperience(xpToAdd);
                 if (!player.capabilities.isCreativeMode) stack.stackSize = 0;
             }
         }


### PR DESCRIPTION
As the title says, this PR aims to make the use of essence berries less annoying by allowing the player to consume whole stacks of them at once when sneaking. 
When a stack of essence berries is consumed, it also doesn't spawn experience orb entities in word but rather adds the experience to the player directly to avoid unnecessary entity spam.
When the player is not sneaking, the berries behave as usual (one berry consumed per click, xp orbs spawn).

https://github.com/GTNewHorizons/TinkersConstruct/assets/93287602/e5789808-ffa2-416f-88d4-e0216700ce61

