### PR TITLE
Implementation of AoE Blacklist for Tinker's Construct Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Forked version of [Tinker's Construct](http://minecraft.curseforge.com/projects/tinkers-construct) being maintained for 1.7.10 for use in the GTNH modpack.
 
-Forked version for Proof of Concept of block filter for AoE effect on TC Tools
+Modify all the things, then do it again!   
+Melt down any metals you find. 	 
+Power the world with spinning wind!
+
+## Development
+
+See the general [GTNH Developement](https://gtnh.miraheze.org/wiki/Development) page.
 
 ## License
 
@@ -13,3 +19,8 @@ This code is licensed LGPL v3.0 or later. Feel free to use our changes, just giv
 The original code is copyright (c) 2015  SlimeKnights and was retroactively released under the MIT License.
 
 Any and all issues with this fork should be brought to the [GTNH GitHub](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues) - do not bother the original maintainers!
+
+## Compile from Source
+Note: Git MUST be installed and in the system path to use our scripts.
+* Before importing the project to your IDE, build it by running `gradlew[.bat] build` in its root directory.
+* If obscure Gradle issues are found try running 'gradlew clean' and 'gradlew cleanCache'

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 Forked version of [Tinker's Construct](http://minecraft.curseforge.com/projects/tinkers-construct) being maintained for 1.7.10 for use in the GTNH modpack.
 
 Forked version for Proof of Concept of block filter for AoE effect on TC Tools
+
+## License
+
+GTNH Modifications Copyright (c) 2021-2024 The GTNH Team
+
+This code is licensed LGPL v3.0 or later. Feel free to use our changes, just give back any changes you make to the community as well!
+
+The original code is copyright (c) 2015  SlimeKnights and was retroactively released under the MIT License.
+
+Any and all issues with this fork should be brought to the [GTNH GitHub](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues) - do not bother the original maintainers!

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -1,5 +1,6 @@
 package tconstruct;
 
+import java.io.File;
 import java.util.Map;
 import java.util.Random;
 
@@ -45,6 +46,7 @@ import tconstruct.library.TConstructCreativeTab;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.Detailing;
 import tconstruct.library.crafting.LiquidCasting;
+import tconstruct.library.util.AoEExclusionList;
 import tconstruct.mechworks.TinkerMechworks;
 import tconstruct.mechworks.landmine.behavior.Behavior;
 import tconstruct.mechworks.landmine.behavior.stackCombo.SpecialStackHandler;
@@ -182,6 +184,8 @@ public class TConstruct {
         tableCasting = new LiquidCasting();
         basinCasting = new LiquidCasting();
         chiselDetailing = new Detailing();
+
+        AoEExclusionList.init(new File(event.getModConfigurationDirectory(), "TConstruct_AOEExclusions.cfg"));
 
         playerTracker = new TPlayerHandler();
         FMLCommonHandler.instance().bus().register(playerTracker);

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -84,25 +84,25 @@ import tconstruct.world.village.VillageToolStationHandler;
  * @author mDiyo
  */
 @Mod(
-    modid = TConstruct.modID,
-    name = "TConstruct",
-    version = TConstruct.modVersion,
-    dependencies = "required-after:Forge@[10.13.3.1384,11.14);"
-        + "required-after:Mantle@[0.3.2,1.7.10),[1.7.10-0.3.2,);"
-        + // make sure we still have the 0.3.2 requirement, even without the 1.7.10 prefix
-        "after:MineFactoryReloaded@[1.7.10R2.8.0RC7,);"
-        + "after:ThermalExpansion@[1.7.10R4.0.0RC2,);"
-        + "after:ThermalFoundation@[1.7.10R1.0.0RC3,);"
-        + "after:armourersWorkshop@[1.7.10-0.28.0,);"
-        + "after:CoFHAPI|energy;"
-        + "after:CoFHCore;"
-        + "after:battlegear2;"
-        + "after:ZeldaItemAPI;"
-        + "after:DynamicSkillsAPI;"
-        + "after:NotEnoughItems;"
-        + "after:Waila;"
-        + "before:GalacticraftCore;"
-        + "before:UndergroundBiomes")
+        modid = TConstruct.modID,
+        name = "TConstruct",
+        version = TConstruct.modVersion,
+        dependencies = "required-after:Forge@[10.13.3.1384,11.14);"
+                + "required-after:Mantle@[0.3.2,1.7.10),[1.7.10-0.3.2,);"
+                + // make sure we still have the 0.3.2 requirement, even without the 1.7.10 prefix
+                "after:MineFactoryReloaded@[1.7.10R2.8.0RC7,);"
+                + "after:ThermalExpansion@[1.7.10R4.0.0RC2,);"
+                + "after:ThermalFoundation@[1.7.10R1.0.0RC3,);"
+                + "after:armourersWorkshop@[1.7.10-0.28.0,);"
+                + "after:CoFHAPI|energy;"
+                + "after:CoFHCore;"
+                + "after:battlegear2;"
+                + "after:ZeldaItemAPI;"
+                + "after:DynamicSkillsAPI;"
+                + "after:NotEnoughItems;"
+                + "after:Waila;"
+                + "before:GalacticraftCore;"
+                + "before:UndergroundBiomes")
 public class TConstruct {
 
     public static final String modVersion = Tags.VERSION;
@@ -130,8 +130,8 @@ public class TConstruct {
 
     /* Loads modules in a way that doesn't clutter the @Mod list */
     public static PulseManager pulsar = new PulseManager(
-        modID,
-        new ForgeCFG("TinkersModules", "Modules: Disabling these will disable a chunk of the mod"));
+            modID,
+            new ForgeCFG("TinkersModules", "Modules: Disabling these will disable a chunk of the mod"));
 
     public TConstruct() {
         if (Loader.isModLoaded("Natura")) {

--- a/src/main/java/tconstruct/items/tools/Excavator.java
+++ b/src/main/java/tconstruct/items/tools/Excavator.java
@@ -14,6 +14,11 @@ public class Excavator extends AOEHarvestTool {
     }
 
     @Override
+    protected String getAOEToolName() {
+        return "excavator";
+    }
+
+    @Override
     protected Material[] getEffectiveMaterials() {
         return materials;
     }

--- a/src/main/java/tconstruct/items/tools/Excavator.java
+++ b/src/main/java/tconstruct/items/tools/Excavator.java
@@ -29,7 +29,7 @@ public class Excavator extends AOEHarvestTool {
     }
 
     static Material[] materials = { Material.grass, Material.ground, Material.sand, Material.snow, Material.craftedSnow,
-        Material.clay };
+            Material.clay };
 
     @Override
     public Item getHeadItem() {

--- a/src/main/java/tconstruct/items/tools/Hammer.java
+++ b/src/main/java/tconstruct/items/tools/Hammer.java
@@ -22,6 +22,11 @@ public class Hammer extends AOEHarvestTool {
     }
 
     @Override
+    protected String getAOEToolName() {
+        return "hammer";
+    }
+
+    @Override
     public int getPartAmount() {
         return 4;
     }

--- a/src/main/java/tconstruct/items/tools/Hammer.java
+++ b/src/main/java/tconstruct/items/tools/Hammer.java
@@ -52,7 +52,7 @@ public class Hammer extends AOEHarvestTool {
     }
 
     static Material[] materials = new Material[] { Material.rock, Material.iron, Material.ice, Material.glass,
-        Material.piston, Material.anvil };
+            Material.piston, Material.anvil };
 
     @Override
     public Item getHeadItem() {
@@ -128,11 +128,11 @@ public class Hammer extends AOEHarvestTool {
         super.getSubItems(id, tab, list);
 
         ItemStack tool = ToolBuilder.instance.buildTool(
-            new ItemStack(getHeadItem(), 1, 10),
-            new ItemStack(getHandleItem(), 1, 8),
-            new ItemStack(getAccessoryItem(), 1, 11),
-            new ItemStack(getExtraItem(), 1, 11),
-            StatCollector.translateToLocal("tool.infiminer"));
+                new ItemStack(getHeadItem(), 1, 10),
+                new ItemStack(getHandleItem(), 1, 8),
+                new ItemStack(getAccessoryItem(), 1, 11),
+                new ItemStack(getExtraItem(), 1, 11),
+                StatCollector.translateToLocal("tool.infiminer"));
 
         NBTTagCompound tags = tool.getTagCompound().getCompoundTag("InfiTool");
         tags.setBoolean("Special", true);

--- a/src/main/java/tconstruct/items/tools/LumberAxe.java
+++ b/src/main/java/tconstruct/items/tools/LumberAxe.java
@@ -36,6 +36,11 @@ public class LumberAxe extends AOEHarvestTool {
     }
 
     @Override
+    protected String getAOEToolName() {
+        return "lumberaxe";
+    }
+
+    @Override
     protected Material[] getEffectiveMaterials() {
         return materials;
     }

--- a/src/main/java/tconstruct/items/tools/LumberAxe.java
+++ b/src/main/java/tconstruct/items/tools/LumberAxe.java
@@ -62,7 +62,7 @@ public class LumberAxe extends AOEHarvestTool {
 
     @Override
     public boolean onBlockDestroyed(ItemStack itemstack, World world, Block block, int x, int y, int z,
-        EntityLivingBase player) {
+            EntityLivingBase player) {
         if (block != null && block.getMaterial() == Material.leaves) return false;
 
         return AbilityHelper.onBlockChanged(itemstack, world, block, x, y, z, player, random);
@@ -151,7 +151,7 @@ public class LumberAxe extends AOEHarvestTool {
             for (int offY = 0; offY < d; offY++) {
                 for (int offZ = 0; offZ < d; offZ++) {
                     int xPos = pos.chunkPosX - 1 + offX, yPos = pos.chunkPosY - 1 + offY,
-                        zPos = pos.chunkPosZ - 1 + offZ;
+                            zPos = pos.chunkPosZ - 1 + offZ;
                     Block leaf = world.getBlock(xPos, yPos, zPos);
                     if (leaf != null && leaf.isLeaves(world, xPos, yPos, zPos)) {
                         if (++leaves >= 5) {
@@ -178,7 +178,7 @@ public class LumberAxe extends AOEHarvestTool {
         public Set<ChunkPosition> visited = new THashSet<>();
 
         public TreeChopTask(AOEHarvestTool tool, ItemStack stack, ChunkPosition start, EntityPlayer player,
-            int blocksPerTick) {
+                int blocksPerTick) {
             this.world = player.getEntityWorld();
             this.player = player;
             this.tool = tool;

--- a/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
@@ -27,7 +27,6 @@ public abstract class AOEHarvestTool extends HarvestTool {
     @Override
     public boolean onBlockStartBreak(ItemStack stack, int x, int y, int z, EntityPlayer player) {
         // only effective materials matter. We don't want to aoe when breaking dirt with a hammer.
-        String toolName = "tool." + getToolName().toLowerCase();
         Block block = player.worldObj.getBlock(x, y, z);
         int meta = player.worldObj.getBlockMetadata(x, y, z);
         if (block == null || !isEffective(block, meta) || !stack.hasTagCompound())

--- a/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
@@ -27,6 +27,7 @@ public abstract class AOEHarvestTool extends HarvestTool {
     @Override
     public boolean onBlockStartBreak(ItemStack stack, int x, int y, int z, EntityPlayer player) {
         // only effective materials matter. We don't want to aoe when breaking dirt with a hammer.
+        String toolName = "tool." + getAOEToolName().toLowerCase();
         Block block = player.worldObj.getBlock(x, y, z);
         int meta = player.worldObj.getBlockMetadata(x, y, z);
         if (block == null || !isEffective(block, meta) || !stack.hasTagCompound())
@@ -71,9 +72,8 @@ public abstract class AOEHarvestTool extends HarvestTool {
                 if (xPos == x && yPos == y && zPos == z) continue;
 
                 Block targetBlock = player.worldObj.getBlock(xPos, yPos, zPos);
-                String blockId = Block.blockRegistry.getNameForObject(targetBlock);
 
-                if (!AoEExclusionList.isBlockExcluded(getAOEToolName(), targetBlock)) {
+                if (!AoEExclusionList.isBlockExcluded(toolName, targetBlock)) {
                     if (!super.onBlockStartBreak(stack, xPos, yPos, zPos, player))
                         breakExtraBlock(player.worldObj, xPos, yPos, zPos, sideHit, player, x, y, z);
                 }

--- a/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
@@ -72,8 +72,9 @@ public abstract class AOEHarvestTool extends HarvestTool {
                 if (xPos == x && yPos == y && zPos == z) continue;
 
                 Block targetBlock = player.worldObj.getBlock(xPos, yPos, zPos);
+                int targetMeta = player.worldObj.getBlockMetadata(xPos, yPos, zPos);
 
-                if (!AoEExclusionList.isBlockExcluded(toolName, targetBlock)) {
+                if (!AoEExclusionList.isBlockExcluded(toolName, targetBlock, targetMeta)) {
                     if (!super.onBlockStartBreak(stack, xPos, yPos, zPos, player))
                         breakExtraBlock(player.worldObj, xPos, yPos, zPos, sideHit, player, x, y, z);
                 }

--- a/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
@@ -28,7 +28,6 @@ public abstract class AOEHarvestTool extends HarvestTool {
     public boolean onBlockStartBreak(ItemStack stack, int x, int y, int z, EntityPlayer player) {
         // only effective materials matter. We don't want to aoe when breaking dirt with a hammer.
         String toolName = "tool." + getToolName().toLowerCase();
-        System.out.println("Full tool name: " + toolName);
         Block block = player.worldObj.getBlock(x, y, z);
         int meta = player.worldObj.getBlockMetadata(x, y, z);
         if (block == null || !isEffective(block, meta) || !stack.hasTagCompound())
@@ -75,24 +74,9 @@ public abstract class AOEHarvestTool extends HarvestTool {
                 Block targetBlock = player.worldObj.getBlock(xPos, yPos, zPos);
                 String blockId = Block.blockRegistry.getNameForObject(targetBlock);
 
-                // Debug logging
-                System.out.println(
-                        "Checking block at " + xPos
-                                + ","
-                                + yPos
-                                + ","
-                                + zPos
-                                + ": "
-                                + targetBlock.getUnlocalizedName());
-                System.out.println("Tool name: " + getAOEToolName());
-                System.out.println("Is excluded: " + AoEExclusionList.isBlockExcluded(getAOEToolName(), targetBlock));
-
                 if (!AoEExclusionList.isBlockExcluded(getAOEToolName(), targetBlock)) {
                     if (!super.onBlockStartBreak(stack, xPos, yPos, zPos, player))
                         breakExtraBlock(player.worldObj, xPos, yPos, zPos, sideHit, player, x, y, z);
-                } else {
-                    // Debug logging
-                    System.out.println("Block " + blockId + " excluded from breaking");
                 }
             }
 

--- a/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
@@ -6,6 +6,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.MovingObjectPosition;
 
+import tconstruct.library.util.AoEExclusionList;
+
 public abstract class AOEHarvestTool extends HarvestTool {
 
     public int breakRadius;
@@ -18,9 +20,15 @@ public abstract class AOEHarvestTool extends HarvestTool {
         this.breakDepth = breakDepth;
     }
 
+    protected String getAOEToolName() {
+        return "tool." + getToolName().toLowerCase();
+    }
+
     @Override
     public boolean onBlockStartBreak(ItemStack stack, int x, int y, int z, EntityPlayer player) {
-        // only effective materials matter. We don't want to aoe when beraking dirt with a hammer.
+        // only effective materials matter. We don't want to aoe when breaking dirt with a hammer.
+        String toolName = "tool." + getToolName().toLowerCase();
+        System.out.println("Full tool name: " + toolName);
         Block block = player.worldObj.getBlock(x, y, z);
         int meta = player.worldObj.getBlockMetadata(x, y, z);
         if (block == null || !isEffective(block, meta) || !stack.hasTagCompound())
@@ -64,8 +72,28 @@ public abstract class AOEHarvestTool extends HarvestTool {
                 // don't break the originally already broken block, duh
                 if (xPos == x && yPos == y && zPos == z) continue;
 
-                if (!super.onBlockStartBreak(stack, xPos, yPos, zPos, player))
-                    breakExtraBlock(player.worldObj, xPos, yPos, zPos, sideHit, player, x, y, z);
+                Block targetBlock = player.worldObj.getBlock(xPos, yPos, zPos);
+                String blockId = Block.blockRegistry.getNameForObject(targetBlock);
+
+                // Debug logging
+                System.out.println(
+                        "Checking block at " + xPos
+                                + ","
+                                + yPos
+                                + ","
+                                + zPos
+                                + ": "
+                                + targetBlock.getUnlocalizedName());
+                System.out.println("Tool name: " + getAOEToolName());
+                System.out.println("Is excluded: " + AoEExclusionList.isBlockExcluded(getAOEToolName(), targetBlock));
+
+                if (!AoEExclusionList.isBlockExcluded(getAOEToolName(), targetBlock)) {
+                    if (!super.onBlockStartBreak(stack, xPos, yPos, zPos, player))
+                        breakExtraBlock(player.worldObj, xPos, yPos, zPos, sideHit, player, x, y, z);
+                } else {
+                    // Debug logging
+                    System.out.println("Block " + blockId + " excluded from breaking");
+                }
             }
 
         return super.onBlockStartBreak(stack, x, y, z, player);

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -39,17 +39,9 @@ public class AoEExclusionList {
     public static boolean isBlockExcluded(String tool, Block block) {
         String[] exclusions = toolExclusionLists.get(tool);
         if (exclusions == null) {
-            // Try with "tool." prefix if it's not present
-            if (!tool.startsWith("tool.")) {
                 exclusions = toolExclusionLists.get("tool." + tool);
-            } else {
-                // Try without "tool." prefix if it's present
-                exclusions = toolExclusionLists.get(tool.substring(5) + "Exclusions");
-            }
         }
-
         String blockId = Block.blockRegistry.getNameForObject(block);
-
         return Arrays.asList(exclusions).contains(blockId);
     }
 }

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -35,11 +35,6 @@ public class AoEExclusionList {
         if (config.hasChanged()) {
             config.save();
         }
-
-        // Print out all loaded exclusion lists
-        for (Map.Entry<String, String[]> entry : toolExclusionLists.entrySet()) {
-            System.out.println("Exclusion list for " + entry.getKey() + ": " + Arrays.toString(entry.getValue()));
-        }
     }
 
     public static boolean isBlockExcluded(String tool, Block block) {
@@ -54,20 +49,8 @@ public class AoEExclusionList {
             }
         }
 
-        if (exclusions == null) {
-            System.out.println("No exclusion list found for tool: " + tool);
-            return false;
-        }
-
         String blockId = Block.blockRegistry.getNameForObject(block);
         boolean isExcluded = Arrays.asList(exclusions).contains(blockId);
-
-        System.out.println(
-                "Checking exclusion for " + tool
-                        + ": Block "
-                        + blockId
-                        + " is "
-                        + (isExcluded ? "excluded" : "not excluded"));
 
         return isExcluded;
     }

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -24,8 +24,8 @@ public class AoEExclusionList {
             String[] exclusionArray = config.getStringList(
                     tool + "Exclusions",
                     "AOE_Exclusions",
-                    new String[] { "examplemod:exampleblock" },
-                    "Block IDs that should not be broken by " + tool + "'s AOE effect");
+                    new String[] { "examplemod:exampleblock", "examplemod:exampleblock:1" },
+                    "Block IDs (with optional metadata) that should not be broken by " + tool + "'s AOE effect");
             Set<String> exclusionSet = new HashSet<>(Arrays.asList(exclusionArray));
             toolExclusionLists.put(tool, exclusionSet);
         }
@@ -35,7 +35,7 @@ public class AoEExclusionList {
         }
     }
 
-    public static boolean isBlockExcluded(String tool, Block block) {
+    public static boolean isBlockExcluded(String tool, Block block, int metadata) {
         Set<String> exclusions = toolExclusionLists.get(tool);
         if (exclusions == null) {
             exclusions = toolExclusionLists.get("tool." + tool);
@@ -46,6 +46,6 @@ public class AoEExclusionList {
         }
 
         String blockId = Block.blockRegistry.getNameForObject(block);
-        return exclusions.contains(blockId);
+        return exclusions.contains(blockId) || exclusions.contains(blockId + ":" + metadata);
     }
 }

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -26,10 +26,9 @@ public class AoEExclusionList {
             String[] exclusionList = config.getStringList(
                     tool + "Exclusions",
                     "AOE_Exclusions",
-                    new String[] {},
+                    new String[] { "examplemod:exampleblock" },
                     "Block IDs that should not be broken by " + tool + "'s AOE effect");
             toolExclusionLists.put(tool, exclusionList);
-            System.out.println("Loaded exclusion list for " + tool + ": " + Arrays.toString(exclusionList));
         }
 
         if (config.hasChanged()) {
@@ -50,8 +49,7 @@ public class AoEExclusionList {
         }
 
         String blockId = Block.blockRegistry.getNameForObject(block);
-        boolean isExcluded = Arrays.asList(exclusions).contains(blockId);
 
-        return isExcluded;
+        return Arrays.asList(exclusions).contains(blockId);
     }
 }

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -1,7 +1,11 @@
 package tconstruct.library.util;
 
 import java.io.File;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import net.minecraft.block.Block;
 import net.minecraftforge.common.config.Configuration;

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -39,7 +39,7 @@ public class AoEExclusionList {
     public static boolean isBlockExcluded(String tool, Block block) {
         String[] exclusions = toolExclusionLists.get(tool);
         if (exclusions == null) {
-                exclusions = toolExclusionLists.get("tool." + tool);
+            exclusions = toolExclusionLists.get("tool." + tool);
         }
         String blockId = Block.blockRegistry.getNameForObject(block);
         return Arrays.asList(exclusions).contains(blockId);

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -1,16 +1,14 @@
 package tconstruct.library.util;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import net.minecraft.block.Block;
 import net.minecraftforge.common.config.Configuration;
 
 public class AoEExclusionList {
 
-    private static final Map<String, String[]> toolExclusionLists = new HashMap<>();
+    private static final Map<String, Set<String>> toolExclusionLists = new HashMap<>();
     private static Configuration config;
 
     public static void init(File configFile) {
@@ -23,12 +21,13 @@ public class AoEExclusionList {
 
         String[] tools = { "tool.hammer", "tool.excavator", "tool.lumberaxe" };
         for (String tool : tools) {
-            String[] exclusionList = config.getStringList(
+            String[] exclusionArray = config.getStringList(
                     tool + "Exclusions",
                     "AOE_Exclusions",
                     new String[] { "examplemod:exampleblock" },
                     "Block IDs that should not be broken by " + tool + "'s AOE effect");
-            toolExclusionLists.put(tool, exclusionList);
+            Set<String> exclusionSet = new HashSet<>(Arrays.asList(exclusionArray));
+            toolExclusionLists.put(tool, exclusionSet);
         }
 
         if (config.hasChanged()) {
@@ -37,11 +36,16 @@ public class AoEExclusionList {
     }
 
     public static boolean isBlockExcluded(String tool, Block block) {
-        String[] exclusions = toolExclusionLists.get(tool);
+        Set<String> exclusions = toolExclusionLists.get(tool);
         if (exclusions == null) {
             exclusions = toolExclusionLists.get("tool." + tool);
         }
+
+        if (exclusions == null || exclusions.isEmpty()) {
+            return false;
+        }
+
         String blockId = Block.blockRegistry.getNameForObject(block);
-        return Arrays.asList(exclusions).contains(blockId);
+        return exclusions.contains(blockId);
     }
 }

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -1,0 +1,74 @@
+package tconstruct.library.util;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraftforge.common.config.Configuration;
+
+public class AoEExclusionList {
+
+    private static final Map<String, String[]> toolExclusionLists = new HashMap<>();
+    private static Configuration config;
+
+    public static void init(File configFile) {
+        config = new Configuration(configFile);
+        loadConfig();
+    }
+
+    private static void loadConfig() {
+        config.load();
+
+        String[] tools = { "tool.hammer", "tool.excavator", "tool.lumberaxe" };
+        for (String tool : tools) {
+            String[] exclusionList = config.getStringList(
+                    tool + "Exclusions",
+                    "AOE_Exclusions",
+                    new String[] {},
+                    "Block IDs that should not be broken by " + tool + "'s AOE effect");
+            toolExclusionLists.put(tool, exclusionList);
+            System.out.println("Loaded exclusion list for " + tool + ": " + Arrays.toString(exclusionList));
+        }
+
+        if (config.hasChanged()) {
+            config.save();
+        }
+
+        // Print out all loaded exclusion lists
+        for (Map.Entry<String, String[]> entry : toolExclusionLists.entrySet()) {
+            System.out.println("Exclusion list for " + entry.getKey() + ": " + Arrays.toString(entry.getValue()));
+        }
+    }
+
+    public static boolean isBlockExcluded(String tool, Block block) {
+        String[] exclusions = toolExclusionLists.get(tool);
+        if (exclusions == null) {
+            // Try with "tool." prefix if it's not present
+            if (!tool.startsWith("tool.")) {
+                exclusions = toolExclusionLists.get("tool." + tool);
+            } else {
+                // Try without "tool." prefix if it's present
+                exclusions = toolExclusionLists.get(tool.substring(5) + "Exclusions");
+            }
+        }
+
+        if (exclusions == null) {
+            System.out.println("No exclusion list found for tool: " + tool);
+            return false;
+        }
+
+        String blockId = Block.blockRegistry.getNameForObject(block);
+        boolean isExcluded = Arrays.asList(exclusions).contains(blockId);
+
+        System.out.println(
+                "Checking exclusion for " + tool
+                        + ": Block "
+                        + blockId
+                        + " is "
+                        + (isExcluded ? "excluded" : "not excluded"));
+
+        return isExcluded;
+    }
+}

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-
 import net.minecraft.block.Block;
 import net.minecraftforge.common.config.Configuration;
 

--- a/src/main/java/tconstruct/library/util/AoEExclusionList.java
+++ b/src/main/java/tconstruct/library/util/AoEExclusionList.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+
 import net.minecraft.block.Block;
 import net.minecraftforge.common.config.Configuration;
 


### PR DESCRIPTION
This feature would enhance control over tool behavior and can prevent accidental destruction of important blocks, think accidentally breaking a wall of chests with a lumber axe, or destroying your Smeltery Controller when breaking Seared brick blocks.

Key Changes:
Created new class under tconstruct.library.util to handle loading and checking exclusions for AoE tool effects.

Lists are determined by a config (preferably pre-set with desired defaults).
Lists are separated into exclusions lists for individual tools, so a separate blacklist can exist for the hammer, separate from the excavator or lumberaxe.

Updated the AOEHarvestTool class to add a check before breaking blocks via AoE, of course keeps original functionality.

Did the whole gauntlet of gradle tests, no issues. Of course i may have missed something so feel free to have a look and/or reject if there was an oversight or you feel it wouldn't fit within the mod/pack as present.


Example of the config file:
```
# Configuration file

aoe_exclusions {
    # Block IDs that should not be broken by tool.excavator's AOE effect [default: ]
    S:tool.excavatorExclusions <
        examplemod:exampleblock
     >

    # Block IDs that should not be broken by tool.hammer's AOE effect [default: ]
    S:tool.hammerExclusions <
        minecraft:furnace
        minecraft:ender_chest
        TConstruct:ToolForgeBlock
        catwalks:scaffold
     >

    # Block IDs that should not be broken by tool.lumberaxe's AOE effect [default: ]
    S:tool.lumberaxeExclusions <
        minecraft:chest
     >
}

```

