### PR TITLE
feat: move tinker tools and weapons to center of crafting station

### DIFF
--- a/src/main/java/tconstruct/tools/inventory/CraftingStationContainer.java
+++ b/src/main/java/tconstruct/tools/inventory/CraftingStationContainer.java
@@ -17,8 +17,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.world.World;
 
+import tconstruct.items.tools.Arrow;
+import tconstruct.items.tools.BowBase;
 import tconstruct.library.crafting.ModifyBuilder;
 import tconstruct.library.modifier.IModifyable;
+import tconstruct.library.tools.HarvestTool;
+import tconstruct.library.tools.Weapon;
+import tconstruct.library.weaponry.AmmoItem;
+import tconstruct.library.weaponry.ProjectileWeapon;
 import tconstruct.tools.TinkerTools;
 import tconstruct.tools.gui.ChestSlot;
 import tconstruct.tools.logic.CraftingStationLogic;
@@ -239,6 +245,22 @@ public class CraftingStationContainer extends Container {
 
     protected boolean moveToCraftingGrid(ItemStack itemstack) {
         if (itemstack == null || itemstack.stackSize <= 0) return false;
+
+        // We make a special check for tinker tools to move into the center of the crafting grid. This makes applying
+        // modifiers just a little bit more convenient.
+        Item item = itemstack.getItem();
+        if (item instanceof Arrow || item instanceof BowBase
+                || item instanceof HarvestTool
+                || item instanceof Weapon
+                || item instanceof AmmoItem
+                || item instanceof ProjectileWeapon) {
+
+            // We simply want to check if we are able to insert it into the center. If not, we continue as normal.
+            boolean wasAbleToInsertIntoCenter = this.mergeItemStack(itemstack, 5, 6, false);
+            if (wasAbleToInsertIntoCenter) {
+                return true;
+            }
+        }
 
         return !this.mergeItemStack(itemstack, 1, 10, true);
     }


### PR DESCRIPTION
This PR is just a quality of life change. When shift-clicking weapons, tools and other tinker stuff into the crafting station, they will now move into the center slot, if possible. If not, the normal transfer logic continues.

Using tinker tools inside the crafting station is only really done to apply modifiers to them. Before this change, the items would always end up in the bottom-right slot.