### PR TITLE
Allow hiding of Traveller's Gear accessories (gloves and belt) through config option and Translucency enchant

### DIFF
--- a/src/main/java/tconstruct/armor/ArmorProxyClient.java
+++ b/src/main/java/tconstruct/armor/ArmorProxyClient.java
@@ -259,7 +259,7 @@ public class ArmorProxyClient extends ArmorProxyCommon {
                 ArmorProxyClient.belt.isChild = event.renderer.modelBipedMain.isChild;
                 ArmorProxyClient.belt.isSneak = event.renderer.modelBipedMain.isSneak;
 
-                renderArmorExtras(event);
+                if (PHConstruct.showTravellerAccessories) renderArmorExtras(event);
 
                 break;
             case 3:

--- a/src/main/java/tconstruct/armor/ArmorProxyClient.java
+++ b/src/main/java/tconstruct/armor/ArmorProxyClient.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -291,9 +292,12 @@ public class ArmorProxyClient extends ArmorProxyCommon {
         translucentID = -1;
     }
 
-    public static int isTranslucent(ItemStack stack) {
+    public static int getTranslucencyLevel(ItemStack stack) {
         int translucent = getTranslucentID();
-        return EnchantmentHelper.getEnchantmentLevel(translucent, stack);
+        if (translucent > 0) 
+            return EnchantmentHelper.getEnchantmentLevel(translucent, stack);
+        else
+            return 0;
     }
 
     // ---
@@ -340,8 +344,8 @@ public class ArmorProxyClient extends ArmorProxyCommon {
         // TPlayerStats stats = TPlayerStats.get(player);
         ArmorExtended armor = ArmorProxyClient.armorExtended; // TODO: Do this for every player, not just the client
         if (armor != null && armor.inventory[1] != null) {
-            if (isTranslucent(armor.inventory[1]) != 2
-                    && !(player.isInvisible() && isTranslucent(armor.inventory[1]) > 0)) {
+            if (getTranslucencyLevel(armor.inventory[1]) != 2
+                    && !(player.isInvisible() && getTranslucencyLevel(armor.inventory[1]) > 0)) {
                 Item item = armor.inventory[1].getItem();
                 ModelBiped model = item.getArmorModel(player, armor.inventory[1], 4);
 
@@ -362,8 +366,8 @@ public class ArmorProxyClient extends ArmorProxyCommon {
         }
 
         if (armor != null && armor.inventory[3] != null) {
-            if (isTranslucent(armor.inventory[3]) != 2
-                    && !(player.isInvisible() && isTranslucent(armor.inventory[3]) > 0)) {
+            if (getTranslucencyLevel(armor.inventory[3]) != 2
+                    && !(player.isInvisible() && getTranslucencyLevel(armor.inventory[3]) > 0)) {
                 Item item = armor.inventory[3].getItem();
                 ModelBiped model = item.getArmorModel(player, armor.inventory[3], 5);
 

--- a/src/main/java/tconstruct/armor/ArmorProxyClient.java
+++ b/src/main/java/tconstruct/armor/ArmorProxyClient.java
@@ -3,12 +3,14 @@ package tconstruct.armor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.model.ModelBiped;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.FOVUpdateEvent;
@@ -271,6 +273,39 @@ public class ArmorProxyClient extends ArmorProxyCommon {
         }
     }
 
+    // --- WitchingGadgets Translucent II enchant support
+    private static int translucentID = -6;
+
+    public static int getTranslucentID() {
+        if (translucentID == -6) setTranslucentID();
+        return translucentID;
+    }
+
+    private static void setTranslucentID() {
+        for (Enchantment ench : Enchantment.enchantmentsList) {
+            if (ench != null && ench.getName().equals("enchantment.wg.invisibleGear")) {
+                translucentID = ench.effectId;
+                return;
+            }
+        }
+        translucentID = -1;
+    }
+
+    public static int isTranslucent(ItemStack stack) {
+        int translucent = getTranslucentID();
+        NBTTagList stackEnch = stack.getEnchantmentTagList();
+        if (translucent >= 0 && stackEnch != null) {
+            for (int i = 0; i < stackEnch.tagCount(); i++) {
+                int id = stackEnch.getCompoundTagAt(i).getInteger("id");
+                int lvl = stackEnch.getCompoundTagAt(i).getInteger("lvl");
+                if (id == translucent) return lvl;
+            }
+        }
+        return 0;
+    }
+
+    // ---
+
     void renderArmorExtras(RenderPlayerEvent.SetArmorModel event) {
 
         EntityPlayer player = event.entityPlayer;
@@ -313,40 +348,46 @@ public class ArmorProxyClient extends ArmorProxyCommon {
         // TPlayerStats stats = TPlayerStats.get(player);
         ArmorExtended armor = ArmorProxyClient.armorExtended; // TODO: Do this for every player, not just the client
         if (armor != null && armor.inventory[1] != null) {
-            Item item = armor.inventory[1].getItem();
-            ModelBiped model = item.getArmorModel(player, armor.inventory[1], 4);
+            if (isTranslucent(armor.inventory[1]) != 2
+                    && !(player.isInvisible() && isTranslucent(armor.inventory[1]) > 0)) {
+                Item item = armor.inventory[1].getItem();
+                ModelBiped model = item.getArmorModel(player, armor.inventory[1], 4);
 
-            if (item instanceof IAccessoryModel) {
-                this.mc.getTextureManager()
-                        .bindTexture(((IAccessoryModel) item).getWearbleTexture(player, armor.inventory[1], 1));
-                model.setLivingAnimations(player, limbSwingMod, limbSwing, partialTick);
-                model.render(
-                        player,
-                        limbSwingMod,
-                        limbSwing,
-                        pitch,
-                        yawRotation - yawOffset,
-                        bodyRotation,
-                        zeropointsixtwofive);
+                if (item instanceof IAccessoryModel) {
+                    this.mc.getTextureManager()
+                            .bindTexture(((IAccessoryModel) item).getWearbleTexture(player, armor.inventory[1], 1));
+                    model.setLivingAnimations(player, limbSwingMod, limbSwing, partialTick);
+                    model.render(
+                            player,
+                            limbSwingMod,
+                            limbSwing,
+                            pitch,
+                            yawRotation - yawOffset,
+                            bodyRotation,
+                            zeropointsixtwofive);
+                }
             }
         }
 
         if (armor != null && armor.inventory[3] != null) {
-            Item item = armor.inventory[3].getItem();
-            ModelBiped model = item.getArmorModel(player, armor.inventory[3], 5);
+            if (isTranslucent(armor.inventory[3]) != 2
+                    && !(player.isInvisible() && isTranslucent(armor.inventory[3]) > 0)) {
+                Item item = armor.inventory[3].getItem();
+                ModelBiped model = item.getArmorModel(player, armor.inventory[3], 5);
 
-            if (item instanceof IAccessoryModel) {
-                this.mc.getTextureManager()
-                        .bindTexture(((IAccessoryModel) item).getWearbleTexture(player, armor.inventory[1], 1));
-                model.setLivingAnimations(player, limbSwingMod, limbSwing, partialTick);
-                model.render(
-                        player,
-                        limbSwingMod,
-                        limbSwing,
-                        pitch,
-                        yawRotation - yawOffset,
-                        bodyRotation,
-                        zeropointsixtwofive);
+                if (item instanceof IAccessoryModel) {
+                    this.mc.getTextureManager()
+                            .bindTexture(((IAccessoryModel) item).getWearbleTexture(player, armor.inventory[1], 1));
+                    model.setLivingAnimations(player, limbSwingMod, limbSwing, partialTick);
+                    model.render(
+                            player,
+                            limbSwingMod,
+                            limbSwing,
+                            pitch,
+                            yawRotation - yawOffset,
+                            bodyRotation,
+                            zeropointsixtwofive);
+                }
             }
         }
     }

--- a/src/main/java/tconstruct/armor/ArmorProxyClient.java
+++ b/src/main/java/tconstruct/armor/ArmorProxyClient.java
@@ -11,7 +11,6 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.FOVUpdateEvent;
@@ -294,10 +293,8 @@ public class ArmorProxyClient extends ArmorProxyCommon {
 
     public static int getTranslucencyLevel(ItemStack stack) {
         int translucent = getTranslucentID();
-        if (translucent > 0) 
-            return EnchantmentHelper.getEnchantmentLevel(translucent, stack);
-        else
-            return 0;
+        if (translucent > 0) return EnchantmentHelper.getEnchantmentLevel(translucent, stack);
+        else return 0;
     }
 
     // ---

--- a/src/main/java/tconstruct/armor/ArmorProxyClient.java
+++ b/src/main/java/tconstruct/armor/ArmorProxyClient.java
@@ -293,15 +293,7 @@ public class ArmorProxyClient extends ArmorProxyCommon {
 
     public static int isTranslucent(ItemStack stack) {
         int translucent = getTranslucentID();
-        NBTTagList stackEnch = stack.getEnchantmentTagList();
-        if (translucent >= 0 && stackEnch != null) {
-            for (int i = 0; i < stackEnch.tagCount(); i++) {
-                int id = stackEnch.getCompoundTagAt(i).getInteger("id");
-                int lvl = stackEnch.getCompoundTagAt(i).getInteger("lvl");
-                if (id == translucent) return lvl;
-            }
-        }
-        return 0;
+        return EnchantmentHelper.getEnchantmentLevel(translucent, stack);
     }
 
     // ---

--- a/src/main/java/tconstruct/armor/player/ArmorExtended.java
+++ b/src/main/java/tconstruct/armor/player/ArmorExtended.java
@@ -219,10 +219,8 @@ public class ArmorExtended implements IInventory {
 
     public static boolean isSoulBounded(ItemStack stack) {
         int soulBound = getSoulBoundID();
-        if(soulBound > 0)
-            return EnchantmentHelper.getEnchantmentLevel(soulBound, stack) > 0;
-        else
-            return false;
+        if (soulBound > 0) return EnchantmentHelper.getEnchantmentLevel(soulBound, stack) > 0;
+        else return false;
     }
 
     // ---

--- a/src/main/java/tconstruct/armor/player/ArmorExtended.java
+++ b/src/main/java/tconstruct/armor/player/ArmorExtended.java
@@ -4,6 +4,7 @@ import java.lang.ref.WeakReference;
 import java.util.UUID;
 
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.IAttributeInstance;
@@ -218,14 +219,10 @@ public class ArmorExtended implements IInventory {
 
     public static boolean isSoulBounded(ItemStack stack) {
         int soulBound = getSoulBoundID();
-        NBTTagList stackEnch = stack.getEnchantmentTagList();
-        if (soulBound >= 0 && stackEnch != null) {
-            for (int i = 0; i < stackEnch.tagCount(); i++) {
-                int id = stackEnch.getCompoundTagAt(i).getInteger("id");
-                if (id == soulBound) return true;
-            }
-        }
-        return false;
+        if(soulBound > 0)
+            return EnchantmentHelper.getEnchantmentLevel(soulBound, stack) > 0;
+        else
+            return false;
     }
 
     // ---

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -250,6 +250,8 @@ public class PHConstruct {
         conTexMode.comment = "0 = disabled, 1 = enabled, 2 = enabled + ignore stained glass meta";
         connectedTexturesMode = conTexMode.getInt(2);
 
+        showTravellerAccessories = config.get("Looks", "Show Traveller Gear Accessories", true).getBoolean(true);
+
         // dimension blacklist
         cfgForbiddenDim = config
                 .get(
@@ -482,6 +484,7 @@ public class PHConstruct {
 
     // Looks
     public static int connectedTexturesMode;
+    public static boolean showTravellerAccessories;
 
     // dimensionblacklist
     public static boolean slimeIslGenDim0Only;


### PR DESCRIPTION
The Traveller's Belt and Glove can now be hidden from rendering on the body through a config option, or they can be enchanted with Translucency I or II from Witching Gadgets and that will work as expected too.  Unfortunately I couldn't figure out how to get the infusion itself to detect the recipe properly with either the glove or the belt, so in order to apply the enchantment you will need to get it onto a book first and apply it with an anvil.