### PR TITLE
Revert default config for option "Remove Gold Cast Recipes"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,10 @@
 // Add your dependencies here
 
 dependencies {
-    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta7:api')
-    api("com.github.GTNewHorizons:Mantle:0.4.1:dev")
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta18:api')
+    api("com.github.GTNewHorizons:Mantle:0.4.2:dev")
     api("com.github.GTNewHorizons:ForgeMultipart:1.5.0:dev")
-    implementation("com.github.GTNewHorizons:NotEnoughItems:2.6.42-GTNH:dev")
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.6.44-GTNH:dev")
     compileOnlyApi("curse.maven:cofh-core-69162:2388751")
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.0:api")
     compileOnly("com.github.GTNewHorizons:waila:1.8.1:api")

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.27'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.29'
 }
 
 

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -58,7 +58,7 @@ public class PHConstruct {
         vanillaMetalBlocks = config.get("Difficulty Changes", "Craft vanilla metal blocks", true).getBoolean(true);
         lavaFortuneInteraction = config.get("Difficulty Changes", "Enable Auto-Smelt and Fortune interaction", true)
                 .getBoolean(true);
-        removeGoldCastRecipes = config.get("Difficulty Changes", "Remove Gold Cast Recipes", true).getBoolean(true);
+        removeGoldCastRecipes = config.get("Difficulty Changes", "Remove Gold Cast Recipes", false).getBoolean(false);
         removeVanillaToolRecipes = config.get("Difficulty Changes", "Remove Vanilla Tool Recipes", false)
                 .getBoolean(false);
         labotimizeVanillaTools = config.get("Difficulty Changes", "Remove Vanilla Tool Effectiveness", false)


### PR DESCRIPTION
Just changes the default to the old value. Doesn't affect GTNH as it is already set there explicitly:

https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/blob/10628584857b5a973d4b45a446a87dcd7746754e/config/TinkersConstruct.cfg#L36

Fixes #128 