### PR TITLE
Explicit GTNH check for gold cast removal config

### DIFF
--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -9,6 +9,7 @@ import net.minecraftforge.common.config.Property;
 
 import com.google.common.collect.Sets;
 
+import cpw.mods.fml.common.Loader;
 import tconstruct.TConstruct;
 import tconstruct.library.tools.AbilityHelper;
 
@@ -58,7 +59,11 @@ public class PHConstruct {
         vanillaMetalBlocks = config.get("Difficulty Changes", "Craft vanilla metal blocks", true).getBoolean(true);
         lavaFortuneInteraction = config.get("Difficulty Changes", "Enable Auto-Smelt and Fortune interaction", true)
                 .getBoolean(true);
-        removeGoldCastRecipes = config.get("Difficulty Changes", "Remove Gold Cast Recipes", false).getBoolean(false);
+
+        boolean removeGoldCastsDefault = Loader.isModLoaded("dreamcraft");
+        removeGoldCastRecipes = config.get("Difficulty Changes", "Remove Gold Cast Recipes", removeGoldCastsDefault)
+                .getBoolean(removeGoldCastsDefault);
+
         removeVanillaToolRecipes = config.get("Difficulty Changes", "Remove Vanilla Tool Recipes", false)
                 .getBoolean(false);
         labotimizeVanillaTools = config.get("Difficulty Changes", "Remove Vanilla Tool Effectiveness", false)


### PR DESCRIPTION
As requested by @Dream-Master and @mitchej123

Set the default value of the "Remove Gold Cast Recipes" option based on whether we are in GTNH. I didn't see the value in adding the GTNH check everywhere the `PHConstruct#removeGoldCastRecipes` field is read.

Follow-up for #130.