### PR TITLE
Fix unlocalized name of Wool Slabs

### DIFF
--- a/src/main/java/tconstruct/world/itemblocks/WoolSlab1Item.java
+++ b/src/main/java/tconstruct/world/itemblocks/WoolSlab1Item.java
@@ -1,11 +1,11 @@
 package tconstruct.world.itemblocks;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockColored;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemDye;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
 import mantle.blocks.abstracts.MultiItemBlock;
@@ -24,8 +24,14 @@ public class WoolSlab1Item extends MultiItemBlock {
 
     @Override
     public String getUnlocalizedName(ItemStack par1ItemStack) {
-        int i = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, 7);
-        return super.getUnlocalizedName() + "." + ItemDye.field_150923_a[7 - i] + ".slab";
+        int dyePos = par1ItemStack.getItemDamage();
+
+        if (dyePos >= 8) {
+            dyePos -= 8;
+        }
+
+        int dye = BlockColored.func_150032_b(dyePos);
+        return super.getUnlocalizedName() + "." + ItemDye.field_150923_a[dye] + ".slab";
     }
 
     @Override

--- a/src/main/java/tconstruct/world/itemblocks/WoolSlab2Item.java
+++ b/src/main/java/tconstruct/world/itemblocks/WoolSlab2Item.java
@@ -1,11 +1,11 @@
 package tconstruct.world.itemblocks;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockColored;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemDye;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
 import mantle.blocks.abstracts.MultiItemBlock;
@@ -29,8 +29,14 @@ public class WoolSlab2Item extends MultiItemBlock {
 
     @Override
     public String getUnlocalizedName(ItemStack par1ItemStack) {
-        int i = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 7, 15);
-        return super.getUnlocalizedName() + "." + ItemDye.field_150923_a[15 - i] + ".slab";
+        int dyePos = par1ItemStack.getItemDamage();
+
+        if (dyePos < 8) {
+            dyePos += 8;
+        }
+
+        int dye = BlockColored.func_150032_b(dyePos);
+        return super.getUnlocalizedName() + "." + ItemDye.field_150923_a[dye] + ".slab";
     }
 
     @Override


### PR DESCRIPTION
There seem to be something odd with the way wool slabs's meta is handled:
- There's `WoolSlab1` which goes from White to gray, and `WoolSlab2` which goes from light gray to black.
- For `WoolSlab1` and `WoolSlab2,` the bottom slab goes from meta 1 -> 7 and top slab from 7 -> 15 (which makes it weird with color meta standard in minecraft).

This commit only fixes the unlocalized name to work according to this logic, without affecting any existing world save.

Fix GTNewHorizons/GT-New-Horizons-Modpack#17826