### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/tinker/lang/en_US.lang
+++ b/src/main/resources/assets/tinker/lang/en_US.lang
@@ -19,6 +19,7 @@ inventory.knapsack=Knapsack
 
 nei.options.keys.gui.tinkers_belt=Toggle Travellers Belt
 
+tile.ToolStation.name=Tool Station
 ToolStation.Crafter.name=Tool Station
 ToolStation.Parts.name=Part Builder
 ToolStation.PatternChest.name=Pattern Chest
@@ -29,6 +30,7 @@ tile.FurnaceSlab.name=Slab Furnace
 tile.ToolForge.name=Tool Forge
 tile.TinkerTable.name=Tinker Table
 tile.Armor.DryingRack.name=Drying Rack
+tile.TConstruct.Soil.name=Soil
 CraftedSoil.Slime.name=Slimy Mud
 CraftedSoil.Grout.name=Grout
 CraftedSoil.BlueSlime.name=Slimy Mud
@@ -39,6 +41,7 @@ tile.slime.channel.name=Slime Channel
 tile.slime.pad.name=Bounce Pad
 tile.blood.channel.name=Blood Channel
 
+tile.tconstruct.stoneore.name=Ore
 MetalOre.NetherSlag.name=Netherack Slag
 MetalOre.Cobalt.name=Cobalt Ore
 MetalOre.Ardite.name=Ardite Ore
@@ -47,6 +50,8 @@ MetalOre.Tin.name=Tin Ore
 MetalOre.Aluminum.name=Aluminum Ore
 MetalOre.Slag.name=Stone Slag
 
+tile.ore.berries.one.name=Oreberry Bush
+tile.ore.berries.two.name=Oreberry Bush
 block.oreberry.iron.name=Iron Oreberry Bush
 block.oreberry.gold.name=Gold Oreberry Bush
 block.oreberry.copper.name=Copper Oreberry Bush
@@ -54,6 +59,7 @@ block.oreberry.tin.name=Tin Oreberry Bush
 block.oreberry.aluminum.name=Aluminum Oreberry Bush
 block.oreberry.essence.name=Essence Berry Bush
 
+tile.tconstruct.gravelore.name=Gravel Ore
 block.ore.gravel.iron.name=Iron Gravel Ore
 block.ore.gravel.gold.name=Gold Gravel Ore
 block.ore.gravel.copper.name=Copper Gravel Ore
@@ -61,6 +67,7 @@ block.ore.gravel.tin.name=Tin Gravel Ore
 block.ore.gravel.aluminum.name=Aluminum Gravel Ore
 block.ore.gravel.cobalt.name=Cobalt Gravel Ore
 
+tile.SpeedBlock.name=Brownstone
 block.brownstone.rough.name=Rough Brownstone
 block.brownstone.rough.road.name=Brownstone Road
 block.brownstone.smooth.name=Brownstone
@@ -69,6 +76,7 @@ block.brownstone.smooth.road.name=Brownstone Road
 block.brownstone.smooth.fancy.name=Fancy Brownstone
 block.brownstone.smooth.chiseled.name=Chiseled Brownstone
 
+tile.SpeedSlab.name=Brownstone Slab
 block.brownstone.rough.slab.name=Rough Brownstone Slab
 block.brownstone.rough.road.slab.name=Brownstone Road Slab
 block.brownstone.smooth.slab.name=Brownstone Slab
@@ -77,6 +85,8 @@ block.brownstone.smooth.road.slab.name=Brownstone Road Slab
 block.brownstone.smooth.fancy.slab.name=Fancy Brownstone Slab
 block.brownstone.smooth.chiseled.slab.name=Chiseled Brownstone Slab
 
+tile.Decoration.Brick.name=Brick
+tile.Decoration.BrickMetal.name=Metal Brick
 block.brick.obsidian.name=Obsidian Brick
 block.brick.sandstone.name=Sandstone Brick
 block.brick.netherrack.name=Netherrack Brick
@@ -96,6 +106,7 @@ block.brick.ardite.name=Ardite Brick
 block.brick.cobalt.name=Cobalt Brick
 block.brick.manyullyn.name=Manyullyn Brick
 
+tile.Decoration.BrickFancy.name=Fancy Brick
 block.fancybrick.obsidian.name=Fancy Obsidian Brick
 block.fancybrick.sandstone.name=Fancy Sandstone Brick
 block.fancybrick.netherrack.name=Fancy Netherrack Brick
@@ -141,6 +152,7 @@ tile.liquid.glue.name=Glue
 
 tile.Frypan.name=Frying Pan
 
+item.oreberry.name=Oreberry
 item.oreberry.iron.name=Iron Oreberry
 item.oreberry.gold.name=Gold Oreberry
 item.oreberry.copper.name=Copper Oreberry
@@ -153,6 +165,7 @@ item.tconstruct.titleicon.name=Spawn
 
 tile.tconstruct.meatblock.name=Hambone
 
+item.InfiTool.name=Tool / Weapon
 item.InfiTool.Pickaxe.name=Pickaxe
 item.InfiTool.Shovel.name=Shovel
 item.InfiTool.Axe.name=Hatchet
@@ -206,6 +219,7 @@ item.tconstruct.PotionLauncher.name=Potion Launcher
 
 item.tool.randomarrow=Random Streamer
 
+item.tconstruct.Pattern.name=Pattern
 item.tconstruct.Pattern.blank_pattern.name=Blank Pattern
 item.tconstruct.Pattern.rod.name=Tool Rod Pattern
 item.tconstruct.Pattern.pickaxe.name=Pickaxe Head Pattern
@@ -238,6 +252,7 @@ item.tconstruct.Pattern.crossbowbody.name=Crossbow Body Pattern
 item.tconstruct.Pattern.bowlimb.name=Bow Limb Pattern
 
 item.tconstruct.Pattern.blank_cast.name=Blank Cast
+item.tconstruct.MetalPattern.name=Cast
 item.tconstruct.MetalPattern.rod.name=Tool Rod Cast
 item.tconstruct.MetalPattern.pickaxe.name=Pickaxe Head Cast
 item.tconstruct.MetalPattern.shovel.name=Shovel Head Cast
@@ -272,6 +287,7 @@ item.tconstruct.MetalPattern.crossbowbody.name=Crossbow Body Cast
 item.tconstruct.MetalPattern.bowlimb.name=Bow Limb Cast
 item.tconstruct.GearPattern.name=Gear Cast
 
+item.tconstruct.ClayPattern.name=Clay Cast
 item.tconstruct.ClayPattern.rod.name=Tool Rod Clay Cast
 item.tconstruct.ClayPattern.pickaxe.name=Pickaxe Head Clay Cast
 item.tconstruct.ClayPattern.shovel.name=Shovel Head Clay Cast
@@ -305,6 +321,7 @@ item.tconstruct.ClayPattern.crossbowlimb.name=Crossbow Limb Clay Cast
 item.tconstruct.ClayPattern.crossbowbody.name=Crossbow Body Clay Cast
 item.tconstruct.ClayPattern.bowlimb.name=Bow Limb Clay Cast
 
+item.tconstruct.Materials.name=Material
 item.tconstruct.Materials.PaperStack.name=Paper Stack
 item.tconstruct.Materials.SlimeCrystal.name=Slime Crystal
 item.tconstruct.Materials.SearedBrick.name=Seared Brick
@@ -366,6 +383,7 @@ item.tconstruct.travelboots.name=Traveller's Boots
 item.tconstruct.travelgloves.name=Traveller's Gloves
 item.tconstruct.travelbelt.name=Traveller's Belt
 
+item.tconstruct.jerky.name=Jerky
 item.tconstruct.jerky.beef.name=Beef Jerky
 item.tconstruct.jerky.pig.name=Bacon Jerky
 item.tconstruct.jerky.chicken.name=Chicken Jerky
@@ -378,6 +396,7 @@ item.tconstruct.jerky.blood.name=Coagulated Blood Drop
 beginnertool.pickaxe=Beginner's Pickaxe
 beginnertool.hatchet=Beginner's Hatchet
 
+tile.Smeltery.name=Smeltery Block
 Smeltery.Controller.name=Smeltery Controller
 Smeltery.Drain.name=Smeltery Drain
 Smeltery.Brick.name=Seared Bricks
@@ -405,6 +424,7 @@ tile.trap.barricade.birch.name=Birch Barricade
 tile.trap.barricade.jungle.name=Jungle Barricade
 tile.explosive.slime.name=SDX
 
+tile.tconstruct.metalblock.name=Block
 StorageMetals.Cobalt.name=Block of Cobalt
 StorageMetals.Ardite.name=Block of Ardite
 StorageMetals.Manyullyn.name=Block of Manyullyn
@@ -419,8 +439,10 @@ StorageMetals.Ender.name=Block of Solid Ender
 
 tile.decoration.stonetorch.name=Torch
 tile.decoration.stoneladder.name=Ladder
+tile.CraftingSlab.name=Crafting Station
 tile.CraftingStation.name=Crafting Station
 
+tile.GlassBlock.name=Glass
 block.glass.pure.name=Clear Glass
 block.glass.soul.name=Soul Glass
 block.glass.soul.pure.name=Clear Soul Glass
@@ -429,6 +451,7 @@ block.glass.pure.pane.name=Clear Glass Pane
 block.glass.soul.pane.name=Soul Pane
 block.glass.soul.pane.pure.name=Clear Soul Pane
 
+tile.GlassBlock.StainedClear.name=Stained Glass
 block.stainedglass.white.name=White Stained Glass
 block.stainedglass.orange.name=Orange Stained Glass
 block.stainedglass.magenta.name=Magenta Stained Glass
@@ -446,6 +469,7 @@ block.stainedglass.green.name=Green Stained Glass
 block.stainedglass.red.name=Red Stained Glass
 block.stainedglass.black.name=Black Stained Glass
 
+tile.tconstruct.glasspanestained.name=Stained Pane
 block.stainedglass.white.pane.name=White Stained Pane
 block.stainedglass.orange.pane.name=Orange Stained Pane
 block.stainedglass.magenta.pane.name=Magenta Stained Pane
@@ -463,6 +487,7 @@ block.stainedglass.green.pane.name=Green Stained Pane
 block.stainedglass.red.pane.name=Red Stained Pane
 block.stainedglass.black.pane.name=Black Stained Pane
 
+tile.SearedSlab.name=Seared Slab
 block.searedstone.slab.brick.name=Seared Brick Slab
 block.searedstone.slab.stone.name=Seared Stone Slab
 block.searedstone.slab.cobble.name=Seared Cobblestone Slab
@@ -481,15 +506,21 @@ block.soil.slab.graveyardsoil.name=Graveyard Soil Slab
 block.soil.slab.consecratedsoil.name=Consecrated Soil Slab
 
 block.slime.soil.blue.name=Blue Slimedirt
+tile.slime.leaves.name=Slimy Leaves
 block.slime.leaves.blue.name=Slimy Leaves
+tile.slime.sapling.name=Slimy Sapling
 block.slime.sapling.bluegreen.name=Slimy Sapling
+tile.slime.grass.name=Slimy Grass
 block.slime.grass.blue.name=Slimy Grass
 block.slime.grass.dirt.name=Slimy Grass
+tile.slime.grass.tall.name=Slimy Grass
 block.slime.tallgrass.name=Slimy Grass
+tile.slime.gel.name=Congealed Slime
 block.slime.congealed.blue.name=Congealed Blue Slime
 block.slime.congealed.green.name=Congealed Green Slime
 block.slime.congealed.purple.name=Congealed Purple Slime
 
+item.tconstruct.storage.name=Knapsack
 item.tconstruct.storage.knapsack.name=Knapsack  
 item.tconstruct.blankpattern.pattern.name=Blank Pattern
 item.tconstruct.blankpattern.cast.name=Blank Cast
@@ -504,12 +535,14 @@ item.tconstruct.Fletching.slime.name=Slime Fletching
 item.tconstruct.Fletching.blueslime.name=Slime Fletching
 item.tconstruct.Fletching.slimeleaf.name=Slimeleaf Fletching
 
+item.tconstruct.manual.name=Manual
 item.tconstruct.manual.beginner.name=Materials and You: Volume 1
 item.tconstruct.manual.toolstation.name=Materials and You: Volume 2
 item.tconstruct.manual.smeltery.name=Mighty Smelting
 item.tconstruct.manual.diary.name=Diary of a Tinker
 item.tconstruct.manual.weaponry.name=Tinkers' Weaponry
 
+item.tconstruct.bucket.name=Bucket
 item.tconstruct.bucket.Iron.name=Molten Iron Bucket
 item.tconstruct.bucket.Gold.name=Molten Gold Bucket
 item.tconstruct.bucket.Copper.name=Molten Copper Bucket
@@ -604,10 +637,13 @@ LiquidMetal.Invar.name=Molten Invar
 LiquidMetal.Electrum.name=Molten Electrum
 LiquidMetal.Ender.name=Liquified Ender
 
+item.tconstruct.apple.diamond.name=Jeweled Apple
 item.food.apple.diamond.name=Jeweled Apple
+item.tconstruct.strangefood.name=Strange Food
 item.tconstruct.strangefood.edibleslime.name=Gelatinous Slime
 item.tconstruct.strangefood.edibleblood.name=Coagulated Blood
 item.tconstruct.strangefood.bacon.name=Bacon
+item.tconstruct.canister.name=Heart Canister
 item.tconstruct.canister.empty.name=Empty Canister
 item.tconstruct.canister.miniheart.red.name=Miniature Red Heart
 item.tconstruct.canister.red.name=Red Heart Canister
@@ -618,6 +654,7 @@ item.tconstruct.canister.green.name=Green Heart Canister
 item.tconstruct.glove.name=Dirtmover Gloves
 item.tconstruct.modifier.creative.name=Creative Tool Modifier
 
+tile.SearedBlock.name=Seared Block
 SearedBlock.Table.name=Casting Table
 SearedBlock.Faucet.name=Seared Faucet
 SearedBlock.Basin.name=Casting Basin
@@ -675,6 +712,38 @@ toolpart.CrossbowBody=%%material Crossbow Body
 toolpart.BowLimb=%%material Bow Limb
 toolpart.Bolt=%%material Bolt
 toolpart.Shaft=%%material Arrow Shaft
+
+item.tconstruct.ArrowHead.name=Arrowhead
+item.tconstruct.AxeHead.name=Axe Head
+item.tconstruct.Binding.name=Binding
+item.tconstruct.Bolt.name=Bolt
+item.tconstruct.BowLimb.name=Bow Limb
+item.tconstruct.Bowstring.name=Bowstring
+item.tconstruct.ChiselHead.name=Chisel Head
+item.tconstruct.Crossbar.name=Crossbar
+item.tconstruct.CrossbowBody.name=Crossbow Body
+item.tconstruct.CrossbowLimb.name=Crossbow Limb
+item.tconstruct.ExcavatorHead.name=Excavator Head
+item.tconstruct.Fletching.name=Fletching
+item.tconstruct.FrypanHead.name=Pan
+item.tconstruct.FullGuard.name=Full Guard
+item.tconstruct.HammerHead.name=Hammer Head
+item.tconstruct.KnifeBlade.name=Knife Blade
+item.tconstruct.LargeGuard.name=Wide Guard
+item.tconstruct.LargePlate.name=Large Plate
+item.tconstruct.LargeSwordBlade.name=Large Sword Blade
+item.tconstruct.LumberAxeHead.name=Broad Axe Head
+item.tconstruct.MediumGuard.name=Hand Guard
+item.tconstruct.PickaxeHead.name=Pickaxe Head
+item.tconstruct.ScytheHead.name=Scythe Head
+item.tconstruct.ShovelHead.name=Shovel Head
+item.tconstruct.Shuriken.name=Shuriken
+item.tconstruct.SignHead.name=Sign Head
+item.tconstruct.SwordBlade.name=Sword Blade
+item.tconstruct.ToolRod.name=Tool Rod
+item.tconstruct.ToolShard.name=Shard
+item.tconstruct.ToughBinding.name=Tough Binding
+item.tconstruct.ToughRod.name=Tough Rod
 
 # Now with translations of specific material and part combinations:
 #toolpart.ToolRod.wood=Wooden Tool Rod
@@ -1013,6 +1082,7 @@ manual.page.modifier3=Tinker Table
 manual.page.casting1=Ingredients
 manual.page.tool1=Crafting Parts
 
+item.tconstruct.glassArrows.name=Glass Arrows
 tool.glassarrows=Glass Arrows
 tool.glassarrows.lore=Crafted by a legendary Glassmaker
 tool.boneana.lore=It sounded like a good idea back then
@@ -1114,6 +1184,7 @@ modifier.tooltip.Triple-Jump=Triple-Jump
 modifier.tooltip.ThaumicVision=Thaumic Vision
 modifier.tooltip.Water-Walking=Water-Walking
 
+tile.LavaTank.name=Seared Tank
 option.tcon.searedtank=Seared Tank
 option.tcon.castingchannel=Casting Channel
 option.tcon.basin=Casting Basin


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.