### PR TITLE
Allow overriding AluminumBrass as the metal pattern material

### DIFF
--- a/src/main/java/tconstruct/library/TConstructRegistry.java
+++ b/src/main/java/tconstruct/library/TConstructRegistry.java
@@ -1,6 +1,5 @@
 package tconstruct.library;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -13,6 +12,7 @@ import net.minecraft.item.ItemStack;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import tconstruct.TConstruct;
 import tconstruct.library.crafting.Detailing;
 import tconstruct.library.crafting.LiquidCasting;
 import tconstruct.library.crafting.ToolBuilder;
@@ -508,62 +508,16 @@ public class TConstructRegistry {
         return null;
     }
 
-    /*
-     * public static CustomMaterial getCustomMaterial(ItemStack input, ItemStack pattern) { for (CustomMaterial mat :
-     * customMaterials) { if (mat.matches(input, pattern)) return mat; } return null; }
-     */
-
-    /*
-     * public static ItemStack craftBowString(ItemStack stack) { if (stack.stackSize < 3) return null; for
-     * (BowstringMaterial mat : bowstringMaterials) { if (stack.isItemEqual(mat.input)) return mat.craftingItem.copy();
-     * } return null; } public static BowstringMaterial getBowstringMaterial(ItemStack stack) { if (stack.stackSize < 3)
-     * return null; for (BowstringMaterial mat : bowstringMaterials) { if (stack.isItemEqual(mat.input)) return mat; }
-     * return null; }
-     */
-
     public static LiquidCasting getTableCasting() {
-        return instance.tableCasting();
-    }
-
-    LiquidCasting tableCasting() {
-        try {
-            Class<?> clazz = Class.forName("tconstruct.TConstruct");
-            Method method = clazz.getMethod("getTableCasting");
-            return (LiquidCasting) method.invoke(this);
-        } catch (Exception e) {
-            logger.warn("Could not find casting table recipes.");
-            return null;
-        }
+        return TConstruct.getTableCasting();
     }
 
     public static LiquidCasting getBasinCasting() {
-        return instance.basinCasting();
-    }
-
-    LiquidCasting basinCasting() {
-        try {
-            Class<?> clazz = Class.forName("tconstruct.TConstruct");
-            Method method = clazz.getMethod("getBasinCasting");
-            return (LiquidCasting) method.invoke(this);
-        } catch (Exception e) {
-            logger.warn("Could not find casting basin recipes.");
-            return null;
-        }
+        return TConstruct.getBasinCasting();
     }
 
     public static Detailing getChiselDetailing() {
-        return instance.chiselDetailing();
-    }
-
-    Detailing chiselDetailing() {
-        try {
-            Class<?> clazz = Class.forName("tconstruct.TConstruct");
-            Method method = clazz.getMethod("getChiselDetailing");
-            return (Detailing) method.invoke(this);
-        } catch (Exception e) {
-            logger.warn("Could not find chisel detailing recipes.");
-            return null;
-        }
+        return TConstruct.getChiselDetailing();
     }
 
     public static ArrayList<ActiveToolMod> activeModifiers = new ArrayList<>();

--- a/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
@@ -188,6 +188,7 @@ public class TinkerSmeltery {
     public static Block speedBlock;
     public static Fluid bloodFluid;
     public static Block blood;
+    private static FluidType metalPatternFluidType;
 
     @Handler
     public void preInit(FMLPreInitializationEvent event) {
@@ -608,6 +609,7 @@ public class TinkerSmeltery {
     @Handler
     public void init(FMLInitializationEvent event) {
         proxy.initialize();
+        loadMetalPatternMaterial();
         craftingTableRecipes();
         addRecipesForSmeltery();
         addRecipesForTableCasting();
@@ -619,6 +621,10 @@ public class TinkerSmeltery {
     public void postInit(FMLPostInitializationEvent evt) {
         addOreDictionarySmelteryRecipes();
         modIntegration();
+    }
+
+    private static void loadMetalPatternMaterial() {
+        metalPatternFluidType = FluidType.getFluidType(PHConstruct.metalCastFluidTypeName);
     }
 
     private void craftingTableRecipes() {
@@ -1000,7 +1006,7 @@ public class TinkerSmeltery {
         // Blank
         tableCasting.addCastingRecipe(
                 new ItemStack(TinkerTools.blankPattern, 1, 1),
-                new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
+                new FluidStack(metalPatternFluidType.fluid, TConstruct.ingotLiquidValue),
                 80);
         if (!PHConstruct.removeGoldCastRecipes) {
             tableCasting.addCastingRecipe(
@@ -1358,7 +1364,7 @@ public class TinkerSmeltery {
             int delay) {
         tableCasting.addCastingRecipe(
                 pattern,
-                new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
+                new FluidStack(metalPatternFluidType.fluid, TConstruct.ingotLiquidValue),
                 shape,
                 delay);
         if (!PHConstruct.removeGoldCastRecipes) {
@@ -1649,7 +1655,7 @@ public class TinkerSmeltery {
 
         // Items
         Smeltery.addMelting(
-                FluidType.getFluidType("AluminumBrass"),
+                metalPatternFluidType,
                 new ItemStack(TinkerTools.blankPattern, 4, 1),
                 -50,
                 TConstruct.ingotLiquidValue);

--- a/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
@@ -1011,18 +1011,7 @@ public class TinkerSmeltery {
 
         // Gem
         ItemStack emerald = new ItemStack(Items.emerald);
-        tableCasting.addCastingRecipe(
-                gemcast,
-                new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                emerald,
-                80);
-        if (!PHConstruct.removeGoldCastRecipes) {
-            tableCasting.addCastingRecipe(
-                    gemcast,
-                    new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                    emerald,
-                    80);
-        }
+        addMetalPatternCastingTableRecipe(tableCasting, gemcast, emerald, 80);
 
         // Ingots
         tableCasting.addCastingRecipe(
@@ -1146,16 +1135,10 @@ public class TinkerSmeltery {
                 ItemStack clay_cast = new ItemStack(TinkerSmeltery.clayPattern, 1, iter + 1);
 
                 // Create metal casts from any existing part that could be melted
-                ItemStack part = new ItemStack(TinkerTools.patternOutputs[iter], 1, Short.MAX_VALUE);
-                tableCasting.addCastingRecipe(
+                addMetalPatternCastingTableRecipe(
+                        tableCasting,
                         cast,
-                        new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                        part,
-                        50);
-                if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
-                        cast,
-                        new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                        part,
+                        new ItemStack(TinkerTools.patternOutputs[iter], 1, Short.MAX_VALUE),
                         50);
 
                 for (int iterTwo = 0; iterTwo < TinkerSmeltery.liquids.length; iterTwo++) {
@@ -1200,29 +1183,14 @@ public class TinkerSmeltery {
         ItemStack[] ingotShapes = { new ItemStack(Items.brick), new ItemStack(Items.netherbrick),
                 new ItemStack(TinkerTools.materials, 1, 2), new ItemStack(TinkerTools.materials, 1, 37) };
         for (ItemStack ingotShape : ingotShapes) {
-            tableCasting.addCastingRecipe(
-                    ingotcast,
-                    new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                    ingotShape,
-                    50);
-            if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
-                    ingotcast,
-                    new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                    ingotShape,
-                    50);
+            addMetalPatternCastingTableRecipe(tableCasting, ingotcast, ingotShape, 50);
         }
 
         ItemStack fullguardCast = new ItemStack(TinkerSmeltery.metalPattern, 1, 22);
-        ItemStack anyFullguardPart = new ItemStack(TinkerTools.fullGuard, 1, Short.MAX_VALUE);
-        tableCasting.addCastingRecipe(
+        addMetalPatternCastingTableRecipe(
+                tableCasting,
                 fullguardCast,
-                new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                anyFullguardPart,
-                50);
-        if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
-                fullguardCast,
-                new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                anyFullguardPart,
+                new ItemStack(TinkerTools.fullGuard, 1, Short.MAX_VALUE),
                 50);
 
         // Golden Food Stuff
@@ -1383,6 +1351,22 @@ public class TinkerSmeltery {
                     ingotcast_clay,
                     true,
                     50); // Steel
+        }
+    }
+
+    public static void addMetalPatternCastingTableRecipe(LiquidCasting tableCasting, ItemStack pattern, ItemStack shape,
+            int delay) {
+        tableCasting.addCastingRecipe(
+                pattern,
+                new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
+                shape,
+                delay);
+        if (!PHConstruct.removeGoldCastRecipes) {
+            tableCasting.addCastingRecipe(
+                    pattern,
+                    new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
+                    shape,
+                    delay);
         }
     }
 
@@ -1921,16 +1905,7 @@ public class TinkerSmeltery {
         for (ItemStack ore : OreDictionary.getOres(name)) {
             // Allow making ingot cast with this ingot
             ItemStack ingot = new ItemStack(ore.getItem(), 1, ore.getItemDamage());
-            tableCasting.addCastingRecipe(
-                    pattern,
-                    new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                    ingot,
-                    50);
-            if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
-                    pattern,
-                    new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                    ingot,
-                    50);
+            addMetalPatternCastingTableRecipe(tableCasting, pattern, ingot, 50);
 
             // Allow casting this ingot using a metal ingot cast
             tableCasting.addCastingRecipe(ingot, new FluidStack(ft.fluid, TConstruct.ingotLiquidValue), pattern, 80);
@@ -1951,16 +1926,7 @@ public class TinkerSmeltery {
             }
             // Allow making nugget cast with this ingot
             ItemStack nugget = new ItemStack(ore.getItem(), 1, ore.getItemDamage());
-            tableCasting.addCastingRecipe(
-                    pattern,
-                    new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                    nugget,
-                    50);
-            if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
-                    pattern,
-                    new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                    nugget,
-                    50);
+            addMetalPatternCastingTableRecipe(tableCasting, pattern, nugget, 50);
 
             // Allow casting this nugget using a metal ingot cast
             tableCasting.addCastingRecipe(nugget, new FluidStack(ft.fluid, TConstruct.nuggetLiquidValue), pattern, 40);

--- a/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
@@ -1002,20 +1002,25 @@ public class TinkerSmeltery {
                 new ItemStack(TinkerTools.blankPattern, 1, 1),
                 new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
                 80);
-        tableCasting.addCastingRecipe(
-                gemcast,
-                new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                new ItemStack(Items.emerald),
-                80);
         if (!PHConstruct.removeGoldCastRecipes) {
             tableCasting.addCastingRecipe(
                     new ItemStack(TinkerTools.blankPattern, 1, 2),
                     new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
                     80);
+        }
+
+        // Gem
+        ItemStack emerald = new ItemStack(Items.emerald);
+        tableCasting.addCastingRecipe(
+                gemcast,
+                new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
+                emerald,
+                80);
+        if (!PHConstruct.removeGoldCastRecipes) {
             tableCasting.addCastingRecipe(
                     gemcast,
                     new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                    new ItemStack(Items.emerald),
+                    emerald,
                     80);
         }
 
@@ -1140,17 +1145,17 @@ public class TinkerSmeltery {
                 ItemStack cast = new ItemStack(TinkerSmeltery.metalPattern, 1, iter + 1);
                 ItemStack clay_cast = new ItemStack(TinkerSmeltery.clayPattern, 1, iter + 1);
 
+                // Create metal casts from any existing part that could be melted
+                ItemStack part = new ItemStack(TinkerTools.patternOutputs[iter], 1, Short.MAX_VALUE);
                 tableCasting.addCastingRecipe(
                         cast,
                         new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                        new ItemStack(TinkerTools.patternOutputs[iter], 1, Short.MAX_VALUE),
-                        false,
+                        part,
                         50);
                 if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
                         cast,
                         new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                        new ItemStack(TinkerTools.patternOutputs[iter], 1, Short.MAX_VALUE),
-                        false,
+                        part,
                         50);
 
                 for (int iterTwo = 0; iterTwo < TinkerSmeltery.liquids.length; iterTwo++) {
@@ -1199,28 +1204,25 @@ public class TinkerSmeltery {
                     ingotcast,
                     new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
                     ingotShape,
-                    false,
                     50);
             if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
                     ingotcast,
                     new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
                     ingotShape,
-                    false,
                     50);
         }
 
         ItemStack fullguardCast = new ItemStack(TinkerSmeltery.metalPattern, 1, 22);
+        ItemStack anyFullguardPart = new ItemStack(TinkerTools.fullGuard, 1, Short.MAX_VALUE);
         tableCasting.addCastingRecipe(
                 fullguardCast,
                 new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                new ItemStack(TinkerTools.fullGuard, 1, Short.MAX_VALUE),
-                false,
+                anyFullguardPart,
                 50);
         if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
                 fullguardCast,
                 new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                new ItemStack(TinkerTools.fullGuard, 1, Short.MAX_VALUE),
-                false,
+                anyFullguardPart,
                 50);
 
         // Golden Food Stuff
@@ -1917,24 +1919,21 @@ public class TinkerSmeltery {
         ItemStack pattern = new ItemStack(TinkerSmeltery.metalPattern, 1, 0);
         LiquidCasting tableCasting = TConstructRegistry.getTableCasting();
         for (ItemStack ore : OreDictionary.getOres(name)) {
+            // Allow making ingot cast with this ingot
+            ItemStack ingot = new ItemStack(ore.getItem(), 1, ore.getItemDamage());
             tableCasting.addCastingRecipe(
                     pattern,
                     new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                    new ItemStack(ore.getItem(), 1, ore.getItemDamage()),
-                    false,
+                    ingot,
                     50);
             if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
                     pattern,
                     new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                    new ItemStack(ore.getItem(), 1, ore.getItemDamage()),
-                    false,
+                    ingot,
                     50);
 
-            tableCasting.addCastingRecipe(
-                    new ItemStack(ore.getItem(), 1, ore.getItemDamage()),
-                    new FluidStack(ft.fluid, TConstruct.ingotLiquidValue),
-                    pattern,
-                    80);
+            // Allow casting this ingot using a metal ingot cast
+            tableCasting.addCastingRecipe(ingot, new FluidStack(ft.fluid, TConstruct.ingotLiquidValue), pattern, 80);
         }
     }
 
@@ -1950,24 +1949,21 @@ public class TinkerSmeltery {
 
                 if (isOreberry) continue;
             }
+            // Allow making nugget cast with this ingot
+            ItemStack nugget = new ItemStack(ore.getItem(), 1, ore.getItemDamage());
             tableCasting.addCastingRecipe(
                     pattern,
                     new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                    new ItemStack(ore.getItem(), 1, ore.getItemDamage()),
-                    false,
+                    nugget,
                     50);
             if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
                     pattern,
                     new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                    new ItemStack(ore.getItem(), 1, ore.getItemDamage()),
-                    false,
+                    nugget,
                     50);
 
-            tableCasting.addCastingRecipe(
-                    new ItemStack(ore.getItem(), 1, ore.getItemDamage()),
-                    new FluidStack(ft.fluid, TConstruct.nuggetLiquidValue),
-                    pattern,
-                    40);
+            // Allow casting this nugget using a metal ingot cast
+            tableCasting.addCastingRecipe(nugget, new FluidStack(ft.fluid, TConstruct.nuggetLiquidValue), pattern, 40);
         }
     }
 

--- a/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
@@ -1667,7 +1667,13 @@ public class TinkerSmeltery {
                 new ItemStack(TinkerTools.blankPattern, 4, 1),
                 -50,
                 TConstruct.ingotLiquidValue);
-        Smeltery.addMelting(gold, new ItemStack(TinkerTools.blankPattern, 4, 2), -50, TConstruct.ingotLiquidValue * 2);
+        if (!PHConstruct.removeGoldCastRecipes) {
+            Smeltery.addMelting(
+                    gold,
+                    new ItemStack(TinkerTools.blankPattern, 4, 2),
+                    -50,
+                    TConstruct.ingotLiquidValue * 2);
+        }
         Smeltery.addMelting(
                 FluidType.getFluidType("Glue"),
                 new ItemStack(TinkerTools.materials, 1, 36),

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -315,6 +315,12 @@ public class PHConstruct {
                         new String[] { "wanion.avaritiaddons.block.chest.infinity.TileEntityInfinityChest" })
                         .getStringList());
 
+        metalCastFluidTypeName = config.get(
+                "CrossmodInteractions",
+                "Metal cast FluidType",
+                "AluminumBrass",
+                "For pack maintainers. Defines the LiquidType used to create metal casts.").getString();
+
         /* Save the configuration file only if it has changed */
         if (config.hasChanged()) config.save();
 
@@ -508,4 +514,7 @@ public class PHConstruct {
     public static boolean extraBlockUpdates;
     public static String[] heartDropBlacklist;
     public static Set<String> craftingStationBlacklist;
+
+    // Crossmod interactions
+    public static String metalCastFluidTypeName;
 }

--- a/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
+++ b/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
@@ -274,16 +274,10 @@ public class TinkerWeaponry {
                 ItemStack cast = new ItemStack(metalPattern, 1, i);
                 ItemStack clay_cast = new ItemStack(clayPattern, 1, i);
 
-                ItemStack part = new ItemStack(patternOutputs[i], 1, Short.MAX_VALUE);
-                tableCasting.addCastingRecipe(
+                TinkerSmeltery.addMetalPatternCastingTableRecipe(
+                        tableCasting,
                         cast,
-                        new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                        part,
-                        50);
-                if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
-                        cast,
-                        new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                        part,
+                        new ItemStack(patternOutputs[i], 1, Short.MAX_VALUE),
                         50);
 
                 for (int iterTwo = 0; iterTwo < TinkerSmeltery.liquids.length; iterTwo++) {
@@ -311,16 +305,10 @@ public class TinkerWeaponry {
             ItemStack cast = new ItemStack(TinkerSmeltery.metalPattern, 1, 25);
             ItemStack clay_cast = new ItemStack(TinkerSmeltery.clayPattern, 1, 25);
 
-            ItemStack arrowHead = new ItemStack(arrowhead, 1, Short.MAX_VALUE);
-            tableCasting.addCastingRecipe(
+            TinkerSmeltery.addMetalPatternCastingTableRecipe(
+                    tableCasting,
                     cast,
-                    new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                    arrowHead,
-                    50);
-            if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
-                    cast,
-                    new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                    arrowHead,
+                    new ItemStack(arrowhead, 1, Short.MAX_VALUE),
                     50);
 
             for (int iterTwo = 0; iterTwo < TinkerSmeltery.liquids.length; iterTwo++) {

--- a/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
+++ b/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
@@ -274,17 +274,16 @@ public class TinkerWeaponry {
                 ItemStack cast = new ItemStack(metalPattern, 1, i);
                 ItemStack clay_cast = new ItemStack(clayPattern, 1, i);
 
+                ItemStack part = new ItemStack(patternOutputs[i], 1, Short.MAX_VALUE);
                 tableCasting.addCastingRecipe(
                         cast,
                         new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                        new ItemStack(patternOutputs[i], 1, Short.MAX_VALUE),
-                        false,
+                        part,
                         50);
                 if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
                         cast,
                         new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                        new ItemStack(patternOutputs[i], 1, Short.MAX_VALUE),
-                        false,
+                        part,
                         50);
 
                 for (int iterTwo = 0; iterTwo < TinkerSmeltery.liquids.length; iterTwo++) {
@@ -312,17 +311,16 @@ public class TinkerWeaponry {
             ItemStack cast = new ItemStack(TinkerSmeltery.metalPattern, 1, 25);
             ItemStack clay_cast = new ItemStack(TinkerSmeltery.clayPattern, 1, 25);
 
+            ItemStack arrowHead = new ItemStack(arrowhead, 1, Short.MAX_VALUE);
             tableCasting.addCastingRecipe(
                     cast,
                     new FluidStack(TinkerSmeltery.moltenAlubrassFluid, TConstruct.ingotLiquidValue),
-                    new ItemStack(arrowhead, 1, Short.MAX_VALUE),
-                    false,
+                    arrowHead,
                     50);
             if (!PHConstruct.removeGoldCastRecipes) tableCasting.addCastingRecipe(
                     cast,
                     new FluidStack(TinkerSmeltery.moltenGoldFluid, TConstruct.ingotLiquidValue * 2),
-                    new ItemStack(arrowhead, 1, Short.MAX_VALUE),
-                    false,
+                    arrowHead,
                     50);
 
             for (int iterTwo = 0; iterTwo < TinkerSmeltery.liquids.length; iterTwo++) {


### PR DESCRIPTION
Adds a config to exchange AluminumBrass for another FluidType register with TiCo during the pre-init phase.

Needed to use GT brass instead of TiCo AluminumBrass in the modpack. I plan to register the FluidType in Dreamcraft.

Also includes some code cleanup which helped me make sure I didn't miss a recipe.

### Sample usage
```
crossmodinteractions {
    # For pack maintainers. Defines the LiquidType used to create metal casts.
    S:"Metal cast FluidType"=Aluminum
}
```

![image](https://github.com/user-attachments/assets/90ad4c09-87e2-4370-a4df-9f19fae3757e)
![image](https://github.com/user-attachments/assets/537372b3-5c79-4d9b-b4a4-1a3717e6579d)
