### PR TITLE
Set tinker tool pickup delay to standard 10 ticks

### DIFF
--- a/src/main/java/tconstruct/tools/entity/FancyEntityItem.java
+++ b/src/main/java/tconstruct/tools/entity/FancyEntityItem.java
@@ -35,7 +35,7 @@ public class FancyEntityItem extends EntityItem {
 
     public FancyEntityItem(World world, Entity original, ItemStack stack) {
         this(world, original.posX, original.posY, original.posZ);
-        this.delayBeforeCanPickup = 20;
+        this.delayBeforeCanPickup = 10;
         this.motionX = original.motionX;
         this.motionY = original.motionY;
         this.motionZ = original.motionZ;


### PR DESCRIPTION
For some reason this was set to 20 (ticks) before, which is double the normal for items. Set it to 10 to match usual behavior