### PR TITLE
feat: let lumberaxe consider diagonal-horizontal log connections

### DIFF
--- a/src/main/java/tconstruct/items/tools/LumberAxe.java
+++ b/src/main/java/tconstruct/items/tools/LumberAxe.java
@@ -243,6 +243,10 @@ public class LumberAxe extends AOEHarvestTool {
                 queueCoordinate(x, y, z + 1);
                 queueCoordinate(x - 1, y, z);
                 queueCoordinate(x, y, z - 1);
+                queueCoordinate(x + 1, y, z + 1);
+                queueCoordinate(x + 1, y, z - 1);
+                queueCoordinate(x - 1, y, z + 1);
+                queueCoordinate(x - 1, y, z - 1);
 
                 // also add the layer above.. stupid acacia trees
                 for (int offX = 0; offX < 3; offX++) {


### PR DESCRIPTION
See also: https://github.com/GTNewHorizons/Natura/pull/31

This PR changes which blocks are scanned when the Lumberaxe loops to find and break connected blocks of the tree.

The previous shape that was scanned around each log was as shown:
![image](https://github.com/user-attachments/assets/1d04ca3c-61da-43c3-99b0-a4a6083a2f83)
As you can see, it scans all 4 direct neighbors of the log, and on the layer above all direct and diaonal neighbors.

After this PR, the scan shape is changed to (the different colors all do the same thing, they are only added for clarity):
![image](https://github.com/user-attachments/assets/14c7479e-f57b-4636-9a92-d367e486d50d)
Blocks diagonally on the same layer as the log are now also queued for checking and breaking.

With this change, tinkers lumberaxes can now also follow shallow-angle diagonal branches like this:
![image](https://github.com/user-attachments/assets/45aad63a-57f4-4430-8a7c-685846cedd7a)
These are, for example, present in the natura tree rework in https://github.com/GTNewHorizons/Natura/pull/31
but also in the BoP "Sacred Oak" tree.  
With this change, the Sacred Oak can now also be fully broken using the lumberaxe, instead of leaving some branches behind.

Possible arguments against this PR
- Performance difference due to 4 more blocks being checked
  - This is a queue-based loop, it is only performed when actually breaking the tree, and has a max number of iterations per tick (which is why the lumberaxe isnt instant). Blocks that are queued multiple times do not get iterated twice. The performance difference should be minute to immeasurably small.
- Possibility of false-positives
  - This change is only on the breaking logic, not the logic that checks wether a log is part of a tree.
  - There is a possibility of false positives, but that is already present in the existing behavior, so fixing this is a separate issue:
![0035303](https://github.com/user-attachments/assets/5c3a7d7e-f44d-432e-94f7-d4843aa84753)
- Behavior of Mechanics should not be changed as other packs may also use the GTNH Tinkers fork
  - I don't know what downsides other packs could get from this change. If really needed, I could put this behind a config option with default being the old behavior?
   