### PR TITLE
Allow the Scythe to harvest crops in an AOE

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,6 +16,7 @@ dependencies {
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnly("com.github.GTNewHorizons:Mobs-Info:0.5.2-GTNH:dev")
     compileOnlyApi("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
+    compileOnlyApi("com.github.GTNewHorizons:Natura:2.7.6:dev")
 
 //    devOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,4 +15,8 @@ dependencies {
     compileOnly("curse.maven:notenoughkeys-224614:2276280")
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnly("com.github.GTNewHorizons:Mobs-Info:0.5.2-GTNH:dev")
+    compileOnlyApi("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
+
+//    devOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
+
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta40:api')
     api("com.github.GTNewHorizons:Mantle:0.5.0:dev")
     api("com.github.GTNewHorizons:ForgeMultipart:1.6.2:dev")
-    implementation("com.github.GTNewHorizons:NotEnoughItems:2.7.31-GTNH:dev")
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.7.34-GTNH:dev")
     compileOnlyApi("curse.maven:cofh-core-69162:2388751")
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:api")
     compileOnly("com.github.GTNewHorizons:waila:1.8.4:api")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,6 +18,10 @@ dependencies {
     compileOnlyApi("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     compileOnlyApi("com.github.GTNewHorizons:Natura:2.7.6:dev")
 
-//    devOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
+    // For testing scythe crop harvesting
+    // devOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
+    // devOnlyNonPublishable("com.github.GTNewHorizons:harvestcraft:1.3.1-GTNH:dev")
+    // devOnlyNonPublishable(deobfCurse("pams-harvest-the-nether-231262:2241397"))
+    // devOnlyNonPublishable("com.github.GTNewHorizons:Natura:2.7.6:dev")
 
 }

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -36,6 +36,8 @@ import mantle.pulsar.control.PulseManager;
 import tconstruct.achievements.AchievementEvents;
 import tconstruct.achievements.TAchievements;
 import tconstruct.api.TConstructAPI;
+import tconstruct.api.harvesting.CropHarvestHandlers;
+import tconstruct.api.harvesting.VanillaCropsHarvestHandler;
 import tconstruct.armor.TinkerArmor;
 import tconstruct.armor.player.TPlayerHandler;
 import tconstruct.armor.player.TPlayerStats;
@@ -227,6 +229,7 @@ public class TConstruct {
         GameRegistry.registerWorldGenerator(new SlimeIslandGen(TinkerWorld.slimePool, 2), 2);
 
         pulsar.init(event);
+        CropHarvestHandlers.registerCropHarvestHandler(new VanillaCropsHarvestHandler());
     }
 
     @EventHandler

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -61,6 +61,7 @@ import tconstruct.plugins.imc.TinkerBuildCraft;
 import tconstruct.plugins.imc.TinkerMystcraft;
 import tconstruct.plugins.imc.TinkerRfTools;
 import tconstruct.plugins.mfr.TinkerMFR;
+import tconstruct.plugins.natura.TinkerNatura;
 import tconstruct.plugins.te4.TinkerTE4;
 import tconstruct.plugins.te4.TinkersThermalFoundation;
 import tconstruct.plugins.ubc.TinkerUBC;
@@ -174,6 +175,7 @@ public class TConstruct {
         pulsar.registerPulse(new TinkerUBC());
         pulsar.registerPulse(new TinkerGears());
         pulsar.registerPulse(new TinkerRfTools());
+        pulsar.registerPulse(new TinkerNatura());
 
         TConstructRegistry.materialTab = new TConstructCreativeTab("TConstructMaterials");
         TConstructRegistry.toolTab = new TConstructCreativeTab("TConstructTools");

--- a/src/main/java/tconstruct/api/harvesting/CropHarvestHandler.java
+++ b/src/main/java/tconstruct/api/harvesting/CropHarvestHandler.java
@@ -1,0 +1,12 @@
+package tconstruct.api.harvesting;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public interface CropHarvestHandler {
+
+    boolean couldHarvest(World world, int x, int y, int z);
+
+    boolean tryHarvest(ItemStack stack, EntityPlayer player, World world, int x, int y, int z);
+}

--- a/src/main/java/tconstruct/api/harvesting/CropHarvestHandlers.java
+++ b/src/main/java/tconstruct/api/harvesting/CropHarvestHandlers.java
@@ -1,0 +1,18 @@
+package tconstruct.api.harvesting;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CropHarvestHandlers {
+
+    private static List<CropHarvestHandler> cropHarvestHandlers = new ArrayList<>();
+
+    public static void registerCropHarvestHandler(CropHarvestHandler handler) {
+        cropHarvestHandlers.add(handler);
+    }
+
+    public static List<CropHarvestHandler> getCropHarvestHandlers() {
+        return Collections.unmodifiableList(cropHarvestHandlers);
+    }
+}

--- a/src/main/java/tconstruct/api/harvesting/VanillaCropsHarvestHandler.java
+++ b/src/main/java/tconstruct/api/harvesting/VanillaCropsHarvestHandler.java
@@ -1,0 +1,25 @@
+package tconstruct.api.harvesting;
+
+import net.minecraft.block.BlockCrops;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public class VanillaCropsHarvestHandler implements CropHarvestHandler {
+
+    @Override
+    public boolean couldHarvest(World world, int x, int y, int z) {
+        return world.getBlock(x, y, z) instanceof BlockCrops;
+    }
+
+    @Override
+    public boolean tryHarvest(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
+        int blockMetadata = world.getBlockMetadata(x, y, z);
+        boolean shouldHarvest = couldHarvest(world, x, y, z) && blockMetadata >= 7;
+        if (shouldHarvest) {
+            world.getBlock(x, y, z).dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
+            world.setBlockMetadataWithNotify(x, y, z, 0, 2);
+        }
+        return shouldHarvest;
+    }
+}

--- a/src/main/java/tconstruct/api/harvesting/VanillaCropsHarvestHandler.java
+++ b/src/main/java/tconstruct/api/harvesting/VanillaCropsHarvestHandler.java
@@ -1,6 +1,7 @@
 package tconstruct.api.harvesting;
 
 import net.minecraft.block.BlockCrops;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
@@ -17,7 +18,13 @@ public class VanillaCropsHarvestHandler implements CropHarvestHandler {
         int blockMetadata = world.getBlockMetadata(x, y, z);
         boolean shouldHarvest = couldHarvest(world, x, y, z) && blockMetadata >= 7;
         if (shouldHarvest) {
-            world.getBlock(x, y, z).dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
+            world.getBlock(x, y, z).dropBlockAsItem(
+                    world,
+                    x,
+                    y,
+                    z,
+                    world.getBlockMetadata(x, y, z),
+                    EnchantmentHelper.getFortuneModifier(player));
             world.setBlockMetadataWithNotify(x, y, z, 0, 2);
         }
         return shouldHarvest;

--- a/src/main/java/tconstruct/items/tools/Scythe.java
+++ b/src/main/java/tconstruct/items/tools/Scythe.java
@@ -301,14 +301,18 @@ public class Scythe extends Weapon {
         if (world.isRemote) {
             return false;
         }
-        if (shouldHarvestInAoe(world, x, y, z)) {
-            harvestInAoe(stack, player, world, x, y, z);
+        if (canPlayerHarvestCrop(world, x, y, z)) {
+            if (player.isSneaking()) {
+                tryHarvestCrop(stack, player, world, x, y, z);
+            } else {
+                harvestInAoe(stack, player, world, x, y, z);
+            }
             return true;
         }
         return false;
     }
 
-    private boolean shouldHarvestInAoe(World world, int x, int y, int z) {
+    private boolean canPlayerHarvestCrop(World world, int x, int y, int z) {
         for (CropHarvestHandler handler : CropHarvestHandlers.getCropHarvestHandlers()) {
             if (handler.couldHarvest(world, x, y, z)) {
                 return true;
@@ -322,7 +326,7 @@ public class Scythe extends Weapon {
             for (int j = -2; j < 3; j++) {
                 for (int k = -2; k < 3; k++) {
                     if (!(stack.getTagCompound().getCompoundTag("InfiTool").getBoolean("Broken"))) {
-                        harvestCrop(stack, player, world, x + i, y + j, z + k);
+                        tryHarvestCrop(stack, player, world, x + i, y + j, z + k);
                     }
                 }
 
@@ -330,7 +334,7 @@ public class Scythe extends Weapon {
         }
     }
 
-    private static void harvestCrop(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
+    private static void tryHarvestCrop(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
         for (CropHarvestHandler handler : CropHarvestHandlers.getCropHarvestHandlers()) {
             if (handler.couldHarvest(world, x, y, z)) {
                 boolean harvestSuccessful = handler.tryHarvest(stack, player, world, x, y, z);

--- a/src/main/java/tconstruct/items/tools/Scythe.java
+++ b/src/main/java/tconstruct/items/tools/Scythe.java
@@ -31,6 +31,7 @@ import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.library.tools.Weapon;
 import tconstruct.tools.TinkerTools;
+import tconstruct.util.config.PHConstruct;
 
 public class Scythe extends Weapon {
 
@@ -298,7 +299,7 @@ public class Scythe extends Weapon {
     @Override
     public boolean onItemUseFirst(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side,
             float hitX, float hitY, float hitZ) {
-        if (world.isRemote) {
+        if (world.isRemote || !PHConstruct.scytheAoeHarvest) {
             return false;
         }
         if (canPlayerHarvestCrop(world, x, y, z)) {

--- a/src/main/java/tconstruct/plugins/ic2/Ic2CropHarvestHandler.java
+++ b/src/main/java/tconstruct/plugins/ic2/Ic2CropHarvestHandler.java
@@ -1,0 +1,22 @@
+package tconstruct.plugins.ic2;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import ic2.api.crops.ICropTile;
+import tconstruct.api.harvesting.CropHarvestHandler;
+
+public class Ic2CropHarvestHandler implements CropHarvestHandler {
+
+    @Override
+    public boolean couldHarvest(World world, int x, int y, int z) {
+        return world.getTileEntity(x, y, z) instanceof ICropTile;
+    }
+
+    @Override
+    public boolean tryHarvest(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
+        return world.getTileEntity(x, y, z) instanceof ICropTile crop && crop.getCrop().canBeHarvested(crop)
+                && crop.harvest(true);
+    }
+}

--- a/src/main/java/tconstruct/plugins/ic2/TinkerIC2.java
+++ b/src/main/java/tconstruct/plugins/ic2/TinkerIC2.java
@@ -11,6 +11,7 @@ import cpw.mods.fml.common.registry.GameRegistry.ObjectHolder;
 import mantle.pulsar.pulse.Handler;
 import mantle.pulsar.pulse.Pulse;
 import tconstruct.TConstruct;
+import tconstruct.api.harvesting.CropHarvestHandlers;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.LiquidCasting;
 
@@ -27,6 +28,8 @@ public class TinkerIC2 {
     @Handler
     public void init(FMLInitializationEvent event) {
         TConstruct.logger.info("IC2 detected. Preparing for shenanigans.");
+
+        CropHarvestHandlers.registerCropHarvestHandler(new Ic2CropHarvestHandler());
 
         Fluid fluidUUM = FluidRegistry.getFluid(IC2_UUM_FLUIDNAME);
         if (fluidUUM == null) return;

--- a/src/main/java/tconstruct/plugins/natura/NaturaCropHarvestHandler.java
+++ b/src/main/java/tconstruct/plugins/natura/NaturaCropHarvestHandler.java
@@ -1,0 +1,31 @@
+package tconstruct.plugins.natura;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import mods.natura.blocks.crops.CropBlock;
+import tconstruct.api.harvesting.CropHarvestHandler;
+
+public class NaturaCropHarvestHandler implements CropHarvestHandler {
+
+    @Override
+    public boolean couldHarvest(World world, int x, int y, int z) {
+        return world.getBlock(x, y, z) instanceof CropBlock;
+    }
+
+    @Override
+    public boolean tryHarvest(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
+        Block block = world.getBlock(x, y, z);
+        if (block instanceof CropBlock crop) {
+            int meta = world.getBlockMetadata(x, y, z);
+            if (meta == crop.getMaxGrowth(meta)) {
+                crop.dropBlockAsItem(world, x, y, z, meta, 0);
+                world.setBlockMetadataWithNotify(x, y, z, crop.getStartGrowth(meta), 2);
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/tconstruct/plugins/natura/NaturaCropHarvestHandler.java
+++ b/src/main/java/tconstruct/plugins/natura/NaturaCropHarvestHandler.java
@@ -1,6 +1,7 @@
 package tconstruct.plugins.natura;
 
 import net.minecraft.block.Block;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
@@ -21,7 +22,7 @@ public class NaturaCropHarvestHandler implements CropHarvestHandler {
         if (block instanceof CropBlock crop) {
             int meta = world.getBlockMetadata(x, y, z);
             if (meta == crop.getMaxGrowth(meta)) {
-                crop.dropBlockAsItem(world, x, y, z, meta, 0);
+                crop.dropBlockAsItem(world, x, y, z, meta, EnchantmentHelper.getFortuneModifier(player));
                 world.setBlockMetadataWithNotify(x, y, z, crop.getStartGrowth(meta), 2);
                 return true;
             }

--- a/src/main/java/tconstruct/plugins/natura/TinkerNatura.java
+++ b/src/main/java/tconstruct/plugins/natura/TinkerNatura.java
@@ -1,0 +1,22 @@
+package tconstruct.plugins.natura;
+
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import mantle.pulsar.pulse.Handler;
+import mantle.pulsar.pulse.Pulse;
+import tconstruct.TConstruct;
+import tconstruct.api.harvesting.CropHarvestHandlers;
+
+@GameRegistry.ObjectHolder(TConstruct.modID)
+@Pulse(
+        id = "Tinkers Natura Compatibility",
+        description = "Tinkers Construct compatibility for Natura",
+        modsRequired = "Natura",
+        forced = true)
+public class TinkerNatura {
+
+    @Handler
+    public void init(FMLInitializationEvent event) {
+        CropHarvestHandlers.registerCropHarvestHandler(new NaturaCropHarvestHandler());
+    }
+}

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -321,6 +321,12 @@ public class PHConstruct {
                 "AluminumBrass",
                 "For pack maintainers. Defines the LiquidType used to create metal casts.").getString();
 
+        scytheAoeHarvest = config.get(
+                "NewFeatures",
+                "Scythe AOE harvest",
+                true,
+                "Can the Scythe harvest crops in an AOE on right click?.").getBoolean();
+
         /* Save the configuration file only if it has changed */
         if (config.hasChanged()) config.save();
 
@@ -517,4 +523,7 @@ public class PHConstruct {
 
     // Crossmod interactions
     public static String metalCastFluidTypeName;
+
+    // New features
+    public static boolean scytheAoeHarvest;
 }


### PR DESCRIPTION
This PR was started to bring the crop harvesting ability of the Gregtech Sense back into the pack after that item was removed in https://github.com/GTNewHorizons/GT5-Unofficial/pull/3203.

To keep things simple, at this time the scythe has the exact same 5x5x5 range that the Sense had, even though it's normal left click destructive harvest ability is still 3x3. I do not have a sensible plan for allowing you to reduce or increase that range without risking enormous scope creep, but suggestions are welcome.

While I was at it, I extended the crop harvesting support to Vanilla, Harvestcraft and Natura crops, as well as the IC2 crops the Sense originally supported.

Note: It is difficult to see in the video but this does use tool durability, though not very much. This could be scaled as desired but I just used the regular durability hit I saw used across the mod.

### Out of scope
- I left out Thaumic Bases and Witchery crops for now. Thaumic bases was just too much of a pain to setup a dev env for, someone can get to it if they want to. For Witchery I got it to work but realized Witchery doesn't have any "gentle harvesting" behavior in the pack since you need to break the crop to harvest it and it technically doesn't guarantee a seed when you do that, so I didn't want to mess with changing the way it wants to be harvested.
- I tried to get Auto smelting to work because it'd be funny, but this would mean changing which base class the Scythe uses or making large changes to the auto smelt code and I didn't want to get into it.
- In theory fortune is applied wherever possible, in practice all crops I  implemented support for ignore fortune in their own code.

## Demo

https://github.com/user-attachments/assets/8fd394cf-d2a7-443e-9d77-696bcf4d41ae
