### PR TITLE
Prevent wasting bone meal on slimy saplings in survival.

### DIFF
--- a/src/main/java/tconstruct/world/TinkerWorldEvents.java
+++ b/src/main/java/tconstruct/world/TinkerWorldEvents.java
@@ -75,6 +75,9 @@ public class TinkerWorldEvents implements IMobExtraInfoProvider {
                 if (TinkerWorld.slimeSapling
                         .boneFertilize(event.world, event.x, event.y, event.z, event.world.rand, event.entityPlayer))
                     event.setResult(Event.Result.ALLOW);
+                else {
+                    event.setCanceled(true);
+                }
             }
         }
     }

--- a/src/main/java/tconstruct/world/TinkerWorldEvents.java
+++ b/src/main/java/tconstruct/world/TinkerWorldEvents.java
@@ -75,9 +75,7 @@ public class TinkerWorldEvents implements IMobExtraInfoProvider {
                 if (TinkerWorld.slimeSapling
                         .boneFertilize(event.world, event.x, event.y, event.z, event.world.rand, event.entityPlayer))
                     event.setResult(Event.Result.ALLOW);
-                else {
-                    event.setCanceled(true);
-                }
+                else event.setCanceled(true);
             }
         }
     }


### PR DESCRIPTION
Cancel the bone meal event if slimeSapling.boneFertilize fails (happens if the player is not in creative mode).
This prevents wasting bone meal that would have no effect. The player will still swing the bone meal, but nothing else will happen.