### PR TITLE
Only check for entities to damage if the structure is valid

### DIFF
--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -325,7 +325,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     }
 
     void detectEntities() {
-        if (minPos == null || maxPos == null) return;
+        if (!validStructure || minPos == null || maxPos == null) return;
 
         AxisAlignedBB box = AxisAlignedBB
                 .getBoundingBox(minPos.x, minPos.y, minPos.z, maxPos.x + 1, minPos.y + layers, maxPos.z + 1);
@@ -334,13 +334,12 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
         for (Entity o : list) {
             if (o.isDead) return;
 
-            if (moltenMetal.size() >= 1) {
+            if (!moltenMetal.isEmpty()) {
                 Fluid fluid = null;
                 int amount = 0;
                 float damage = 5;
 
-                if (o instanceof EntityVillager && PHConstruct.meltableVillagers) {
-                    EntityVillager villager = (EntityVillager) o;
+                if (o instanceof EntityVillager villager && PHConstruct.meltableVillagers) {
                     fluid = TinkerSmeltery.moltenEmeraldFluid;
                     amount = villager.isChild() ? 5 : 40;
                 } else if (o instanceof EntityEnderman) {


### PR DESCRIPTION
This code previously damaged entities (and voided the gained fluids) in the original bounds of a smeltery that was made invalid but still had liquid in its controller.

Before:

https://github.com/user-attachments/assets/e2ada461-30b7-402e-8a5a-cb43e5fe466c

After:

https://github.com/user-attachments/assets/cf3f6d00-62b9-40ed-a97c-af2e2e0032f7

Also simplify the empty check and use a pattern variable in this method.