### PR TITLE
Make the Scythe AOE harvest ability compatible with EnderCore

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,5 +23,6 @@ dependencies {
     // devOnlyNonPublishable("com.github.GTNewHorizons:harvestcraft:1.3.1-GTNH:dev")
     // devOnlyNonPublishable(deobfCurse("pams-harvest-the-nether-231262:2241397"))
     // devOnlyNonPublishable("com.github.GTNewHorizons:Natura:2.8.5:dev")
+    // devOnlyNonPublishable("com.github.GTNewHorizons:EnderCore:0.4.6")
 
 }

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -36,6 +36,7 @@ import mantle.pulsar.control.PulseManager;
 import tconstruct.achievements.AchievementEvents;
 import tconstruct.achievements.TAchievements;
 import tconstruct.api.TConstructAPI;
+import tconstruct.api.harvesting.AoeCropHarvestHandler;
 import tconstruct.api.harvesting.CropHarvestHandlers;
 import tconstruct.api.harvesting.VanillaCropsHarvestHandler;
 import tconstruct.armor.TinkerArmor;
@@ -231,7 +232,10 @@ public class TConstruct {
         GameRegistry.registerWorldGenerator(new SlimeIslandGen(TinkerWorld.slimePool, 2), 2);
 
         pulsar.init(event);
-        CropHarvestHandlers.registerCropHarvestHandler(new VanillaCropsHarvestHandler());
+        if (PHConstruct.scytheAoeHarvest) {
+            CropHarvestHandlers.registerCropHarvestHandler(new VanillaCropsHarvestHandler());
+            MinecraftForge.EVENT_BUS.register(new AoeCropHarvestHandler());
+        }
     }
 
     @EventHandler

--- a/src/main/java/tconstruct/api/harvesting/AoeCropHarvestHandler.java
+++ b/src/main/java/tconstruct/api/harvesting/AoeCropHarvestHandler.java
@@ -1,0 +1,76 @@
+package tconstruct.api.harvesting;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import tconstruct.items.tools.Scythe;
+import tconstruct.library.tools.AbilityHelper;
+
+public class AoeCropHarvestHandler {
+
+    /**
+     * We're using EventPriority.HIGH here to run before RightClickCropHandler from EnderCore.
+     */
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public void handlePlayerInteractEvent(PlayerInteractEvent event) {
+        ItemStack equippedItem = event.entityPlayer.getCurrentEquippedItem();
+        if (!event.world.isRemote && isScythe(equippedItem)
+                && harvestCropsInRange(equippedItem, event.entityPlayer, event.world, event.x, event.y, event.z)) {
+            event.setCanceled(true);
+        }
+    }
+
+    private static boolean isScythe(ItemStack stack) {
+        return stack != null && stack.getItem() instanceof Scythe;
+    }
+
+    private static boolean harvestCropsInRange(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
+        boolean harvesting = canPlayerHarvestCrop(world, x, y, z);
+        if (harvesting) {
+            if (player.isSneaking()) {
+                tryHarvestCrop(stack, player, world, x, y, z);
+            } else {
+                harvestInAoe(stack, player, world, x, y, z);
+            }
+        }
+        return harvesting;
+    }
+
+    private static boolean canPlayerHarvestCrop(World world, int x, int y, int z) {
+        for (CropHarvestHandler handler : CropHarvestHandlers.getCropHarvestHandlers()) {
+            if (handler.couldHarvest(world, x, y, z)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void harvestInAoe(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
+        for (int i = -2; i < 3; i++) {
+            for (int j = -2; j < 3; j++) {
+                for (int k = -2; k < 3; k++) {
+                    if (!(stack.getTagCompound().getCompoundTag("InfiTool").getBoolean("Broken"))) {
+                        tryHarvestCrop(stack, player, world, x + i, y + j, z + k);
+                    }
+                }
+
+            }
+        }
+    }
+
+    private static void tryHarvestCrop(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
+        for (CropHarvestHandler handler : CropHarvestHandlers.getCropHarvestHandlers()) {
+            if (handler.couldHarvest(world, x, y, z)) {
+                boolean harvestSuccessful = handler.tryHarvest(stack, player, world, x, y, z);
+                if (harvestSuccessful && !player.capabilities.isCreativeMode) {
+                    AbilityHelper.damageTool(stack, 1, null, false);
+                }
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/tconstruct/items/tools/Scythe.java
+++ b/src/main/java/tconstruct/items/tools/Scythe.java
@@ -24,14 +24,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.IShearable;
 
 import cpw.mods.fml.client.FMLClientHandler;
-import tconstruct.api.harvesting.CropHarvestHandler;
-import tconstruct.api.harvesting.CropHarvestHandlers;
 import tconstruct.library.ActiveToolMod;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.library.tools.Weapon;
 import tconstruct.tools.TinkerTools;
-import tconstruct.util.config.PHConstruct;
 
 public class Scythe extends Weapon {
 
@@ -294,56 +291,5 @@ public class Scythe extends Weapon {
             AbilityHelper.onLeftClickEntity(stack, player, e, this);
         }
         return true;
-    }
-
-    @Override
-    public boolean onItemUseFirst(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side,
-            float hitX, float hitY, float hitZ) {
-        if (world.isRemote || !PHConstruct.scytheAoeHarvest) {
-            return false;
-        }
-        if (canPlayerHarvestCrop(world, x, y, z)) {
-            if (player.isSneaking()) {
-                tryHarvestCrop(stack, player, world, x, y, z);
-            } else {
-                harvestInAoe(stack, player, world, x, y, z);
-            }
-            return true;
-        }
-        return false;
-    }
-
-    private boolean canPlayerHarvestCrop(World world, int x, int y, int z) {
-        for (CropHarvestHandler handler : CropHarvestHandlers.getCropHarvestHandlers()) {
-            if (handler.couldHarvest(world, x, y, z)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private void harvestInAoe(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
-        for (int i = -2; i < 3; i++) {
-            for (int j = -2; j < 3; j++) {
-                for (int k = -2; k < 3; k++) {
-                    if (!(stack.getTagCompound().getCompoundTag("InfiTool").getBoolean("Broken"))) {
-                        tryHarvestCrop(stack, player, world, x + i, y + j, z + k);
-                    }
-                }
-
-            }
-        }
-    }
-
-    private static void tryHarvestCrop(ItemStack stack, EntityPlayer player, World world, int x, int y, int z) {
-        for (CropHarvestHandler handler : CropHarvestHandlers.getCropHarvestHandlers()) {
-            if (handler.couldHarvest(world, x, y, z)) {
-                boolean harvestSuccessful = handler.tryHarvest(stack, player, world, x, y, z);
-                if (harvestSuccessful && !player.capabilities.isCreativeMode) {
-                    AbilityHelper.damageTool(stack, 1, null, false);
-                }
-                return;
-            }
-        }
     }
 }


### PR DESCRIPTION
Makes https://github.com/GTNewHorizons/TinkersConstruct/pull/159 compatible with [RightClickCropHandler.java](https://github.com/GTNewHorizons/EnderCore/blob/master/src/main/java/com/enderio/core/common/handlers/RightClickCropHandler.java) which otherwise runs first and cancels the player interaction.