### PR TITLE
Restore the wooden rail

### DIFF
--- a/src/main/java/tconstruct/world/TinkerWorld.java
+++ b/src/main/java/tconstruct/world/TinkerWorld.java
@@ -72,6 +72,7 @@ import tconstruct.world.blocks.SlimePad;
 import tconstruct.world.blocks.StoneLadder;
 import tconstruct.world.blocks.StoneTorch;
 import tconstruct.world.blocks.TMetalBlock;
+import tconstruct.world.blocks.WoodRail;
 import tconstruct.world.entity.BlueSlime;
 import tconstruct.world.entity.Crystal;
 import tconstruct.world.entity.KingBlueSlime;
@@ -136,6 +137,8 @@ public class TinkerWorld {
     public static OreberryBush oreBerry;
     public static OreberryBush oreBerrySecond;
     public static Item oreBerries;
+    // Rail-related
+    public static Block woodenRail;
     // Chest hooks
     public static ChestGenHooks tinkerHouseChest;
     public static ChestGenHooks tinkerHousePatterns;
@@ -238,6 +241,11 @@ public class TinkerWorld {
         TinkerWorld.oreGravel.setHarvestLevel("shovel", 1, 3);
         TinkerWorld.oreGravel.setHarvestLevel("shovel", 1, 4);
         TinkerWorld.oreGravel.setHarvestLevel("shovel", 4, 5);
+        // Rail
+        if (!Loader.isModLoaded("dreamcraft")) {
+            TinkerWorld.woodenRail = new WoodRail().setStepSound(Block.soundTypeWood)
+                    .setCreativeTab(TConstructRegistry.blockTab).setBlockName("rail.wood");
+        }
 
         GameRegistry.registerBlock(TinkerWorld.meatBlock, HamboneItemBlock.class, "MeatBlock");
         OreDictionary.registerOre("hambone", new ItemStack(TinkerWorld.meatBlock));
@@ -283,6 +291,11 @@ public class TinkerWorld {
         GameRegistry.registerBlock(TinkerWorld.oreBerrySecond, OreberryBushSecondItem.class, "ore.berries.two");
         GameRegistry.registerBlock(TinkerWorld.oreSlag, MetalOreItemBlock.class, "SearedBrick");
         GameRegistry.registerBlock(TinkerWorld.oreGravel, GravelOreItem.class, "GravelOre");
+
+        // Rail
+        if (TinkerWorld.woodenRail != null) {
+            GameRegistry.registerBlock(TinkerWorld.woodenRail, "rail.wood");
+        }
 
         // Items
         goldHead = new GoldenHead(4, 1.2F, false).setAlwaysEdible().setPotionEffect(Potion.regeneration.id, 10, 0, 1.0F)
@@ -669,6 +682,19 @@ public class TinkerWorld {
         // Stone Ladder Recipe
         GameRegistry.addRecipe(
                 new ShapedOreRecipe(new ItemStack(TinkerWorld.stoneLadder, 3), "w w", "www", "w w", 'w', "rodStone"));
+        // Wooden Rail (if registered) Recipe
+        if (TinkerWorld.woodenRail != null) {
+            GameRegistry.addRecipe(
+                    new ShapedOreRecipe(
+                            new ItemStack(TinkerWorld.woodenRail, 4, 0),
+                            "b b",
+                            "bxb",
+                            "b b",
+                            'b',
+                            "plankWood",
+                            'x',
+                            "stickWood"));
+        }
         // Stonesticks Recipes
         GameRegistry.addRecipe(new ItemStack(TinkerTools.toolRod, 4, 1), "c", "c", 'c', new ItemStack(Blocks.stone));
         GameRegistry

--- a/src/main/java/tconstruct/world/blocks/WoodRail.java
+++ b/src/main/java/tconstruct/world/blocks/WoodRail.java
@@ -1,0 +1,54 @@
+package tconstruct.world.blocks;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRailBase;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.item.EntityMinecart;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class WoodRail extends BlockRailBase {
+
+    @SideOnly(Side.CLIENT)
+    private IIcon theIcon;
+
+    public WoodRail() {
+        super(false);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    /**
+     * From the specified side and block metadata retrieves the blocks texture. Args: side, metadata
+     */
+    public IIcon getIcon(int par1, int par2) {
+        return par2 >= 6 ? this.theIcon : this.blockIcon;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    /**
+     * When this method is called, your block should register all the icons it needs with the given IconRegister. This
+     * is the only chance you get to register icons.
+     */
+    public void registerBlockIcons(IIconRegister par1IconRegister) {
+        this.blockIcon = par1IconRegister.registerIcon("tinker:woodrail");
+        this.theIcon = par1IconRegister.registerIcon("tinker:woodrail_turn");
+    }
+
+    protected void func_94358_a(World par1World, int par2, int par3, int par4, int par5, int par6, Block par7) {
+        if (par7 != Blocks.air && par7.canProvidePower()
+                && (new Rail(par1World, par2, par3, par4)).func_150650_a() == 3) {
+            this.func_150052_a(par1World, par2, par3, par4, false);
+        }
+    }
+
+    @Override
+    public float getRailMaxSpeed(World world, EntityMinecart cart, int y, int x, int z) {
+        return 0.3f;
+    }
+}

--- a/src/main/resources/assets/tinker/lang/cs_CZ.lang
+++ b/src/main/resources/assets/tinker/lang/cs_CZ.lang
@@ -114,6 +114,8 @@ block.fancybrick.ardite.name=Hezké arditové cihly
 block.fancybrick.cobalt.name=Hezké kobaltové cihly
 block.fancybrick.manyullyn.name=Hezké manyullynové cihly
 
+tile.rail.wood.name=Dřevěná kolej
+
 tile.cloth.white.slab.name=Vlnový půlblok
 tile.cloth.orange.slab.name=Oranžový vlnový půlblok
 tile.cloth.magenta.slab.name=Purporový vlnový půlblok

--- a/src/main/resources/assets/tinker/lang/de_DE.lang
+++ b/src/main/resources/assets/tinker/lang/de_DE.lang
@@ -114,6 +114,8 @@ block.fancybrick.ardite.name=Schicke Arditeziegel
 block.fancybrick.cobalt.name=Schicke Kobaltziegel
 block.fancybrick.manyullyn.name=Schicke Manyullynziegel
 
+tile.rail.wood.name=Hölzerne Schiene
+
 tile.cloth.white.slab.name=Wollstufe
 tile.cloth.orange.slab.name=Orange Wollstufe
 tile.cloth.magenta.slab.name=Magenta Wollstufe

--- a/src/main/resources/assets/tinker/lang/en_PT.lang
+++ b/src/main/resources/assets/tinker/lang/en_PT.lang
@@ -105,6 +105,8 @@ block.fancybrick.obsidian.ingot.name=Fancy Obsidian Brick
 block.fancybrick.stone.road.name=Stone Road
 block.fancybrick.stone.name=Fancy Stone Brick
 
+tile.rail.wood.name=Timbers Ta Shiver
+
 tile.cloth.white.slab.name=Wool Slab
 tile.cloth.orange.slab.name=Orange Wool Slab
 tile.cloth.magenta.slab.name=Magenta Wool Slab

--- a/src/main/resources/assets/tinker/lang/en_US.lang
+++ b/src/main/resources/assets/tinker/lang/en_US.lang
@@ -128,6 +128,8 @@ block.fancybrick.ardite.name=Fancy Ardite Brick
 block.fancybrick.cobalt.name=Fancy Cobalt Brick
 block.fancybrick.manyullyn.name=Fancy Manyullyn Brick
 
+tile.rail.wood.name=Wooden Rail
+
 tile.cloth.white.slab.name=Wool Slab
 tile.cloth.orange.slab.name=Orange Wool Slab
 tile.cloth.magenta.slab.name=Magenta Wool Slab

--- a/src/main/resources/assets/tinker/lang/fr_FR.lang
+++ b/src/main/resources/assets/tinker/lang/fr_FR.lang
@@ -114,6 +114,8 @@ block.fancybrick.ardite.name=Brique d'ardite chic
 block.fancybrick.cobalt.name=Brique de cobalt chic
 block.fancybrick.manyullyn.name=Brique de manyullyn chic
 
+tile.rail.wood.name=Rail en bois
+
 tile.cloth.white.slab.name=Dalle de laine
 tile.cloth.orange.slab.name=Dalle de laine orange
 tile.cloth.magenta.slab.name=Dalle de laine magenta

--- a/src/main/resources/assets/tinker/lang/it_IT.lang
+++ b/src/main/resources/assets/tinker/lang/it_IT.lang
@@ -106,6 +106,8 @@ block.fancybrick.obsidian.ingot.name=Ossidiana concia decorativa
 block.fancybrick.stone.road.name=Strada di pietra
 block.fancybrick.stone.name=Pietra concia decorativa
 
+tile.rail.wood.name=Rotaia di legno
+
 tile.cloth.white.slab.name=Lastra di lana bianca
 tile.cloth.orange.slab.name=Lastra di lana arancione
 tile.cloth.magenta.slab.name=Lastra di lana magenta

--- a/src/main/resources/assets/tinker/lang/ja_JP.lang
+++ b/src/main/resources/assets/tinker/lang/ja_JP.lang
@@ -106,6 +106,8 @@ block.fancybrick.obsidian.ingot.name=Fancy Obsidian Brick
 block.fancybrick.stone.road.name=Stone Road
 block.fancybrick.stone.name=Fancy Stone Brick
 
+tile.rail.wood.name=木のレール
+
 tile.cloth.white.slab.name=羊毛ハーフブロック
 tile.cloth.orange.slab.name=橙色の羊毛ハーフブロック
 tile.cloth.magenta.slab.name=赤紫色の羊毛ハーフブロック

--- a/src/main/resources/assets/tinker/lang/ko_KR.lang
+++ b/src/main/resources/assets/tinker/lang/ko_KR.lang
@@ -106,6 +106,8 @@ block.fancybrick.obsidian.ingot.name=화려한 흑요석 주괴 벽돌
 block.fancybrick.stone.road.name=돌 도로
 block.fancybrick.stone.name=화려한 석재 벽돌
 
+tile.rail.wood.name=나무 레일
+
 tile.cloth.white.slab.name=양털 반 블럭
 tile.cloth.orange.slab.name=주황색 양털 반 블럭
 tile.cloth.magenta.slab.name=다홍색 양털 반 블럭

--- a/src/main/resources/assets/tinker/lang/pt_BR.lang
+++ b/src/main/resources/assets/tinker/lang/pt_BR.lang
@@ -106,6 +106,8 @@ block.fancybrick.obsidian.ingot.name=Tijolo Bonito de Obsidiana
 block.fancybrick.stone.road.name=Pavimento de Pedra
 block.fancybrick.stone.name=Tijolo Bonito de Pedra
 
+tile.rail.wood.name=Trilho de Madeira
+
 tile.cloth.white.slab.name=Laje de Lã
 tile.cloth.orange.slab.name=Laje de Lã Laranja
 tile.cloth.magenta.slab.name=Laje de Lã Magenta

--- a/src/main/resources/assets/tinker/lang/pt_PT.lang
+++ b/src/main/resources/assets/tinker/lang/pt_PT.lang
@@ -106,6 +106,8 @@ block.fancybrick.obsidian.ingot.name=Tijolo Bonito de Obsidiana
 block.fancybrick.stone.road.name=Pavimento de Pedra
 block.fancybrick.stone.name=Tijolo Bonito de Pedra
 
+tile.rail.wood.name=Trilho de Madeira
+
 tile.cloth.white.slab.name=Laje de Lã
 tile.cloth.orange.slab.name=Laje de Lã Laranja
 tile.cloth.magenta.slab.name=Laje de Lã Magenta

--- a/src/main/resources/assets/tinker/lang/ru_RU.lang
+++ b/src/main/resources/assets/tinker/lang/ru_RU.lang
@@ -117,6 +117,8 @@ block.fancybrick.ardite.name=Красивый ардитовый кирпич
 block.fancybrick.cobalt.name=Красивый кобальтовый кирпич
 block.fancybrick.manyullyn.name=Красивый мануллиновый кирпич
 
+tile.rail.wood.name=Деревянные рельсы
+
 tile.cloth.white.slab.name=Плита из шерсти
 tile.cloth.orange.slab.name=Плита из оранжевой шерсти
 tile.cloth.magenta.slab.name=Плита из сиреневой шерсти

--- a/src/main/resources/assets/tinker/lang/uk_UA.lang
+++ b/src/main/resources/assets/tinker/lang/uk_UA.lang
@@ -116,6 +116,8 @@ block.fancybrick.ardite.name=Вишукана ардитова цегла
 block.fancybrick.cobalt.name=Вишукана кобальтова цегла
 block.fancybrick.manyullyn.name=Вишукана манулінова цегла
 
+tile.rail.wood.name=Дерев'яні рейки
+
 tile.cloth.white.slab.name=Вовняна плита
 tile.cloth.orange.slab.name=Помаранчева вовняна плита
 tile.cloth.magenta.slab.name=Пурпурова вовняна плита

--- a/src/main/resources/assets/tinker/lang/zh_CN.lang
+++ b/src/main/resources/assets/tinker/lang/zh_CN.lang
@@ -116,6 +116,8 @@ block.fancybrick.ardite.name=平滑阿迪特砖块
 block.fancybrick.cobalt.name=平滑钴砖块
 block.fancybrick.manyullyn.name=平滑玛玉灵砖块
 
+tile.rail.wood.name=木轨道
+
 tile.cloth.white.slab.name=羊毛台阶
 tile.cloth.orange.slab.name=橙色羊毛台阶
 tile.cloth.magenta.slab.name=品红色羊毛台阶

--- a/src/main/resources/assets/tinker/lang/zh_TW.lang
+++ b/src/main/resources/assets/tinker/lang/zh_TW.lang
@@ -105,6 +105,8 @@ block.fancybrick.obsidian.ingot.name=平滑黑曜石錠磚塊
 block.fancybrick.stone.road.name=鋪路石塊
 block.fancybrick.stone.name=平滑石磚塊
 
+tile.rail.wood.name=木軌道
+
 tile.cloth.white.slab.name=羊毛台階
 tile.cloth.orange.slab.name=橙色羊毛台階
 tile.cloth.magenta.slab.name=品紅色羊毛台階

--- a/src/main/resources/assets/tinker/manuals/en_US/diary.xml
+++ b/src/main/resources/assets/tinker/manuals/en_US/diary.xml
@@ -4,7 +4,7 @@
 <page type="text">
 <text>Tinker's Log #1:
 
-Today is a new day. I finally left home and decided to wander around in the wilderness until I find a good place to call my home. 
+Today is a new day. I finally left home and decided to wander around in the wilderness until I find a good place to call my home.
 
 Tinker's Log #2:
 
@@ -66,7 +66,7 @@ Perhaps making a tool completely out of stone wasn't the best idea. It didn't la
 <page type="text">
 <text>Tinker's Log #13:
 
-I wanted to make a few more tools, but the boards with tool shapes in them went everywhere! I ended up breaking a few out of frustration. They don't fit very well in my chest either. I took a few of them, added a few slots to the bottom of the chest, placed it by my table and called it good. 
+I wanted to make a few more tools, but the boards with tool shapes in them went everywhere! I ended up breaking a few out of frustration. They don't fit very well in my chest either. I took a few of them, added a few slots to the bottom of the chest, placed it by my table and called it good.
 
 I also named them "Patterns", the chest a "Pattern Chest". I'm still angry at them, and it took so long to make new ones...</text>
 </page>
@@ -74,7 +74,7 @@ I also named them "Patterns", the chest a "Pattern Chest". I'm still angry at th
 <page type="text">
 <text>Tinker's Log #14
 
-Today I learned just how hard it was to shape iron. First you have to dig it out of the earth. A wooden pickaxe will shatter the ore; this I found out the hard way. Once you do get that ore there isn't much to do with it besides throw it in the furnace. Melting the iron and the stone seems inefficient, but I do need the metal more than I care about the waste. 
+Today I learned just how hard it was to shape iron. First you have to dig it out of the earth. A wooden pickaxe will shatter the ore; this I found out the hard way. Once you do get that ore there isn't much to do with it besides throw it in the furnace. Melting the iron and the stone seems inefficient, but I do need the metal more than I care about the waste.
 
 I shaped a few of the bars into tools, and they felt strong. Much stronger, in fact, than the ones back at the village. I've named the pickaxe "Krug" after some of the stories Nana used to tell me at night. How I miss her...</text>
 </page>
@@ -92,7 +92,7 @@ A week later and I've finally found some others to visit. Some of them seem nice
 <page type="text">
 <text>Tinker's Log #17:
 
-After three days and nights of fending off zombies, I've finally created a house. It has a few rooms, a basement, but most importantly a workshop. All of the tables and patterns I had before are here, as well as a few others I wanted to try out from the trip. 
+After three days and nights of fending off zombies, I've finally created a house. It has a few rooms, a basement, but most importantly a workshop. All of the tables and patterns I had before are here, as well as a few others I wanted to try out from the trip.
 
 There's a round one I can cook food with and one that's just as good as any hoe, but can chop trees or actually dig the ground up. The villagers tell me these are named "Frying Pan" and "Mattock". The Frying Pan seems heavy enough to smack creepers with. I have a sword named "Shimmer" that I want to alter somehow.</text>
 </page>
@@ -106,7 +106,7 @@ One of the villagers was kind enough to give me some random things. Each one loo
 <page type="text">
 <text>Tinker's Log #19:
 
-After some heavy experimentation, I've ended up with some things that look amazing and others that look less useful than they actually are. A diamond tip on a pickaxe makes for a wonderfully hard mining tool, and an emerald on a sword hilt somehow makes it stay together longer, but some things don't do anything. 
+After some heavy experimentation, I've ended up with some things that look amazing and others that look less useful than they actually are. A diamond tip on a pickaxe makes for a wonderfully hard mining tool, and an emerald on a sword hilt somehow makes it stay together longer, but some things don't do anything.
 
 Adding flowers to a tool does nothing; they don't even stay on the thing. Mushrooms have a similar effect, and adding more material to a tool just makes it heavier. You wouldn't think redstone would do anything. I've coated a shovel so much that it looks deep red. However, it slides through dirt as if the dirt wasn't there.</text>
 </page>
@@ -131,22 +131,24 @@ I have some ideas for creating tools, but for that I need a large place to creat
 
 <page type="text">
 <text>Tinker's Log #23:
+
 I have all these tools laying around with little notes on what each one does. Instead of leaving them scattered about, I think I will create one place to store them.
 
 Tinker's Log #24:
 
-I went exploring and found some new ores today. They're colors I've never seen before, and they don't shatter on impact like iron does. I wonder what I can do with these?
-</text>
+I went exploring and found some new ores today. They're colors I've never seen before, and they don't shatter on impact like iron does. I wonder what I can do with these?</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #25:
+
+The normal furnace is nice for keeping warm, but it leaves something to be desired for processing metal. I've dug a pit and lined it with some clay, gathered lava nearby, and put ore in the center in an attempt to improve on the design. The results were quite interesting.</text>
 </page>
 
 <page type="text">
 <text>
-Tinker's Log #25:
-
-The normal furnace is nice for keeping warm, but it leaves something to be desired for processing metal. I've dug a pit and lined it with some clay, gathered lava nearby, and put ore in the center in an attempt to improve on the design. The results were quite interesting.</text>
-
 The more lava I fed into the pit the hotter the material became. Eventually the whole thing liquified. I broke open the side of the pit with a cauldron in an attempt to catch the material, but it went everywhere. There were some remnants left in the pit as well.
 
-Raw ore still has parts of stone in it. There must be a way to remove the excess.
+Raw ore still has parts of stone in it. There must be a way to remove the excess.</text>
 </page>
 </book>


### PR DESCRIPTION
The rail will only be registered if `dreamcraft` IS NOT present.
The rail recipe obey `disableAllRecipes` as usual.

This partially reverts commit 75919e5bf70bce2ecd6e52d1b00ff7e7cc510fee.