### PR TITLE
Casting Table/Basin Facing Directions

### DIFF
--- a/src/main/java/tconstruct/smeltery/logic/FaucetLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/FaucetLogic.java
@@ -6,6 +6,7 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.MathHelper;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -18,7 +19,7 @@ import tconstruct.TConstruct;
 
 public class FaucetLogic extends TileEntity implements IFacingLogic, IActiveLogic, IFluidHandler {
 
-    byte direction;
+    byte direction = 0;
     boolean active;
     public FluidStack liquid;
     public boolean hasRedstonePower = false;
@@ -91,17 +92,20 @@ public class FaucetLogic extends TileEntity implements IFacingLogic, IActiveLogi
     public void setDirection(int side) {
         if (side != 0 && side != 1) {
             direction = (byte) side;
-        } else {
-            direction = 2;
         }
     }
 
     @Override
     public void setDirection(float yaw, float pitch, EntityLivingBase player) {
-        /*
-         * int facing = MathHelper.floor_double((double) (yaw / 360) + 0.5D) & 3; switch (facing) { case 0: direction =
-         * 2; break; case 1: direction = 5; break; case 2: direction = 3; break; case 3: direction = 4; break; }
-         */
+        if (direction > 1) return;
+
+        int facing = MathHelper.floor_double((double) (yaw / 360) + 0.5D) & 3;
+        switch (facing) {
+            case 1 -> direction = 5;
+            case 2 -> direction = 3;
+            case 3 -> direction = 4;
+            default -> direction = 2;
+        }
     }
 
     @Override

--- a/src/main/java/tconstruct/smeltery/model/CastingBasinSpecialRender.java
+++ b/src/main/java/tconstruct/smeltery/model/CastingBasinSpecialRender.java
@@ -47,11 +47,20 @@ public class CastingBasinSpecialRender extends TileEntitySpecialRenderer {
         entityitem.hoverStart = 0.0F;
         GL11.glPushMatrix();
         GL11.glTranslatef(1F, 0.675F, 1.0F);
-        // GL11.glRotatef(90F, 1, 0F, 0F);
+
+        float rotationY = switch (logic.getRenderDirection()) {
+            case 2 -> 90F;
+            case 3 -> 270F;
+            case 4 -> 180F;
+            default -> 0F;
+        };
+
+        GL11.glRotatef(rotationY, 0F, 1F, 0F);
         GL11.glScalef(1.75F, 1.75F, 1.75F);
+
         if (stack.getItem() instanceof ItemBlock) {
             GL11.glScalef(1.6F, 1.6F, 1.6F);
-            GL11.glTranslatef(0F, 0.045F, 0.0f);
+            GL11.glTranslatef(0F, 0.045F, 0F);
         } else if (!(stack.getItem() instanceof ItemBlocklike)) {
             GL11.glRotatef(90F, 1F, 0F, 0F);
             GL11.glRotatef(90F, 0F, 0F, 1F);

--- a/src/main/java/tconstruct/smeltery/model/CastingTableSpecialRenderer.java
+++ b/src/main/java/tconstruct/smeltery/model/CastingTableSpecialRenderer.java
@@ -53,11 +53,30 @@ public class CastingTableSpecialRenderer extends TileEntitySpecialRenderer {
         entityitem.hoverStart = 0.0F;
         GL11.glPushMatrix();
         GL11.glTranslatef(1F, 1.48F, 0.55F);
-        GL11.glRotatef(90F, 1, 0F, 0F);
+
+        float rotationY = switch (logic.getRenderDirection()) {
+            case 3 -> 180F;
+            case 4 -> 90F;
+            case 5 -> 270F;
+            default -> 0F;
+        };
+        GL11.glRotatef(rotationY, 0F, 1F, 0F);
+
+        if (logic.getRenderDirection() == 3) {
+            GL11.glTranslatef(0F, 0F, -0.9F);
+        } else if (logic.getRenderDirection() == 4) {
+            GL11.glTranslatef(-0.45F, 0F, -0.45F);
+        } else if (logic.getRenderDirection() == 5) {
+            GL11.glTranslatef(0.45F, 0F, -0.45F);
+        }
+
+        GL11.glRotatef(90F, 1F, 0F, 0F);
         GL11.glScalef(2F, 2F, 2F);
+
         if (stack.getItem() instanceof ItemBlock || stack.getItem() instanceof ItemBlocklike) {
-            GL11.glRotatef(90F, -1, 0F, 0F);
-            GL11.glTranslatef(0F, -0.1F, 0.2275F);
+            GL11.glRotatef(-90F, 0F, 0F, 1F);
+            GL11.glRotatef(90F, -1F, 0F, 0F);
+            GL11.glTranslatef(-0.2275F, -0.1F, 0F);
         }
 
         if (stack.isItemEqual(new ItemStack(TinkerSmeltery.glassPane))) {


### PR DESCRIPTION
Casting Tables and Basins can now face all four cardinal directions rather than just one (repeaters for block facing reference):
![image](https://github.com/user-attachments/assets/a8d5d11a-80a2-4a38-bc87-d857597e1524)

The direction chosen is based on the direction the player is facing when placing the block (the value is saved to the TE's NBT).

Also made a fix for the logic used when placing Seared Faucets while looking at the top or bottom of a block. It now defers to the other method that uses the player's rotation if the player doesn't place it against the side of a block.