### PR TITLE
Battlegear 2 for Backhand compat

### DIFF
--- a/src/main/java/tconstruct/compat/Battlegear2Compat.java
+++ b/src/main/java/tconstruct/compat/Battlegear2Compat.java
@@ -1,0 +1,17 @@
+package tconstruct.compat;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+import mods.battlegear2.api.core.IInventoryPlayerBattle;
+
+/**
+ * This class exists to isolate classes that exist in Battlegear 2 but not in Battlegear 2 for Backhand in order to
+ * avoid class loading exceptions.
+ */
+public class Battlegear2Compat {
+
+    public static ItemStack getBattlegear2Offhand(EntityPlayer player) {
+        return ((IInventoryPlayerBattle) player.inventory).battlegear2$getCurrentOffhandWeapon();
+    }
+}

--- a/src/main/java/tconstruct/library/weaponry/BowBaseAmmo.java
+++ b/src/main/java/tconstruct/library/weaponry/BowBaseAmmo.java
@@ -13,7 +13,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.common.Loader;
-import mods.battlegear2.api.core.IInventoryPlayerBattle;
+import mods.battlegear2.api.core.IBattlePlayer;
+import tconstruct.compat.Battlegear2Compat;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.tools.BowstringMaterial;
@@ -62,8 +63,9 @@ public abstract class BowBaseAmmo extends ProjectileWeapon {
     @Override
     public ItemStack searchForAmmo(EntityPlayer player, ItemStack weapon) {
         // arrow priority: hotbar > inventory, tinker arrows > regular arrows
-        if (isBattlegear2Loaded) {
-            ItemStack offhand = ((IInventoryPlayerBattle) player.inventory).battlegear2$getCurrentOffhandWeapon();
+        if (isBattlegear2Loaded && player instanceof IBattlePlayer battlePlayer
+                && battlePlayer.battlegear2$isBattlemode()) {
+            ItemStack offhand = Battlegear2Compat.getBattlegear2Offhand(player);
             if (checkTinkerArrow(offhand) || checkVanillaArrow(offhand)) {
                 return offhand;
             }

--- a/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
+++ b/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
@@ -12,7 +12,8 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.common.Loader;
-import mods.battlegear2.api.core.IInventoryPlayerBattle;
+import mods.battlegear2.api.core.IBattlePlayer;
+import tconstruct.compat.Battlegear2Compat;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.tools.AbilityHelper;
@@ -224,8 +225,9 @@ public class Crossbow extends ProjectileWeapon {
     @Override
     public ItemStack searchForAmmo(EntityPlayer player, ItemStack weapon) {
         // arrow priority: hotbar > inventory, tinker arrows > regular arrows
-        if (isBattlegear2Loaded) {
-            ItemStack offhand = ((IInventoryPlayerBattle) player.inventory).battlegear2$getCurrentOffhandWeapon();
+        if (isBattlegear2Loaded && player instanceof IBattlePlayer battlePlayer
+                && battlePlayer.battlegear2$isBattlemode()) {
+            ItemStack offhand = Battlegear2Compat.getBattlegear2Offhand(player);
             if (offhand != null && (offhand.getItem() instanceof BoltAmmo)
                     && ((IAmmo) offhand.getItem()).getAmmoCount(offhand) > 0) {
                 return offhand;


### PR DESCRIPTION
Battlegear 2 for Backhand has `IBattlePlayer` but not `IInventoryPlayerBattle` so that latter class needs to be placed somewhere where it won't be class loaded. This works because `battlegear2$isBattlemode` is always false for the Backhand edition of BG2.