### PR TITLE
Fix the ender pearl clay gem pattern casting recipe

### DIFF
--- a/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
@@ -1184,7 +1184,7 @@ public class TinkerSmeltery {
         tableCasting.addCastingRecipe(
                 new ItemStack(Items.ender_pearl),
                 new FluidStack(TinkerSmeltery.moltenEnderFluid, 250),
-                new ItemStack(TinkerSmeltery.clayPattern, 1, 18),
+                new ItemStack(TinkerSmeltery.clayPattern, 1, 26),
                 true,
                 50);
 


### PR DESCRIPTION
There is a not working recipe for ender pearls which requires a cast that doesn't exist.
![enderpearl_bug](https://github.com/user-attachments/assets/7a158b7c-e12e-45ee-80d7-f5b74e2781c7)
The name of the missing texture item is `item.tconstruct.ClayPattern..name`, which doesn't exist. 


I replaced the broken pattern in the recipe with a gem pattern as that is probably what was intended - there are working recipes for casting ender pearls which use the metal gem and pan casts.
![enderpearl_fixed](https://github.com/user-attachments/assets/78e13d33-3552-44d5-8107-5a9c6f08dbb1)
