### PR TITLE
Allow Ammo in Bauble Slots

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,6 +17,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Mobs-Info:0.5.3-GTNH:dev")
     compileOnlyApi("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     compileOnlyApi("com.github.GTNewHorizons:Natura:2.8.8:dev")
+    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH:dev')
 
     // For testing scythe crop harvesting
     // devOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -107,8 +107,7 @@ import tconstruct.world.village.VillageToolStationHandler;
                 + "after:NotEnoughItems;"
                 + "after:Waila;"
                 + "before:GalacticraftCore;"
-                + "before:UndergroundBiomes;"
-                + "after:Baubles|Expanded")
+                + "before:UndergroundBiomes")
 public class TConstruct {
 
     public static final String modVersion = Tags.VERSION;

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -138,8 +138,6 @@ public class TConstruct {
             modID,
             new ForgeCFG("TinkersModules", "Modules: Disabling these will disable a chunk of the mod"));
 
-    public static final String AMMOBAUBLESLOT = "quiver";
-
     public TConstruct() {
         if (Loader.isModLoaded("Natura")) {
             logger.info("Natura, what are we going to do tomorrow night?");
@@ -226,8 +224,8 @@ public class TConstruct {
         TConstructAPI.PROP_NAME = TPlayerStats.PROP_NAME;
 
         if (LoadedMods.baublesExpanded) {
-            BaubleExpandedSlots.tryRegisterType(AMMOBAUBLESLOT);
-            BaubleExpandedSlots.tryAssignSlotOfType(AMMOBAUBLESLOT);
+            BaubleExpandedSlots.tryRegisterType(BaubleExpandedSlots.quiverType);
+            BaubleExpandedSlots.tryAssignSlotOfType(BaubleExpandedSlots.quiverType);
         }
     }
 

--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -12,6 +12,7 @@ import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import baubles.api.expanded.BaubleExpandedSlots;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
@@ -42,6 +43,7 @@ import tconstruct.armor.TinkerArmor;
 import tconstruct.armor.player.TPlayerHandler;
 import tconstruct.armor.player.TPlayerStats;
 import tconstruct.common.TProxyCommon;
+import tconstruct.compat.LoadedMods;
 import tconstruct.gadgets.TinkerGadgets;
 import tconstruct.library.SlimeBounceHandler;
 import tconstruct.library.TConstructCreativeTab;
@@ -105,7 +107,8 @@ import tconstruct.world.village.VillageToolStationHandler;
                 + "after:NotEnoughItems;"
                 + "after:Waila;"
                 + "before:GalacticraftCore;"
-                + "before:UndergroundBiomes")
+                + "before:UndergroundBiomes;"
+                + "after:Baubles|Expanded")
 public class TConstruct {
 
     public static final String modVersion = Tags.VERSION;
@@ -135,6 +138,8 @@ public class TConstruct {
     public static PulseManager pulsar = new PulseManager(
             modID,
             new ForgeCFG("TinkersModules", "Modules: Disabling these will disable a chunk of the mod"));
+
+    public static final String AMMOBAUBLESLOT = "quiver";
 
     public TConstruct() {
         if (Loader.isModLoaded("Natura")) {
@@ -220,6 +225,11 @@ public class TConstruct {
         }
 
         TConstructAPI.PROP_NAME = TPlayerStats.PROP_NAME;
+
+        if (LoadedMods.baublesExpanded) {
+            BaubleExpandedSlots.tryRegisterType(AMMOBAUBLESLOT);
+            BaubleExpandedSlots.tryAssignSlotOfType(AMMOBAUBLESLOT);
+        }
     }
 
     @EventHandler

--- a/src/main/java/tconstruct/compat/LoadedMods.java
+++ b/src/main/java/tconstruct/compat/LoadedMods.java
@@ -1,0 +1,12 @@
+package tconstruct.compat;
+
+import cpw.mods.fml.common.Loader;
+
+public class LoadedMods {
+
+    public static final boolean battlegear2 = Loader.isModLoaded("battlegear2");
+    public static final boolean baubles = Loader.isModLoaded("Baubles");
+    public static final boolean baublesExpanded = Loader.isModLoaded("Baubles|Expanded");
+    public static final boolean tiCTooltips = Loader.isModLoaded("TiCTooltips");
+
+}

--- a/src/main/java/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/tconstruct/library/tools/ToolCore.java
@@ -260,7 +260,7 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
     /* Tags and information about the tool */
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean par4) {
+    public void addInformation(ItemStack stack, EntityPlayer player, List<String> list, boolean advanced) {
         if (!stack.hasTagCompound()) return;
 
         NBTTagCompound tags = stack.getTagCompound();
@@ -269,9 +269,9 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
             int RF = tags.getInteger("Energy");
 
             if (RF != 0) {
-                if (RF <= this.getMaxEnergyStored(stack) / 3) color = "\u00a74";
-                else if (RF > this.getMaxEnergyStored(stack) * 2 / 3) color = "\u00a72";
-                else color = "\u00a76";
+                if (RF <= this.getMaxEnergyStored(stack) / 3) color = EnumChatFormatting.DARK_RED.toString();
+                else if (RF > this.getMaxEnergyStored(stack) * 2 / 3) color = EnumChatFormatting.DARK_GREEN.toString();
+                else color = EnumChatFormatting.GOLD.toString();
             }
 
             String energy = color + tags.getInteger("Energy") + "/" + getMaxEnergyStored(stack) + " RF";
@@ -279,7 +279,7 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
         }
         if (tags.hasKey("InfiTool")) {
             boolean broken = tags.getCompoundTag("InfiTool").getBoolean("Broken");
-            if (broken) list.add("\u00A7o" + StatCollector.translateToLocal("tool.core.broken"));
+            if (broken) list.add(EnumChatFormatting.ITALIC + StatCollector.translateToLocal("tool.core.broken"));
             else {
                 int head = tags.getCompoundTag("InfiTool").getInteger("Head");
                 int handle = tags.getCompoundTag("InfiTool").getInteger("Handle");
@@ -287,26 +287,26 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
                 int extra = tags.getCompoundTag("InfiTool").getInteger("Extra");
 
                 String headName = getAbilityNameForType(head, 0);
-                if (!headName.equals("")) list.add(getStyleForType(head) + headName);
+                if (!headName.isEmpty()) list.add(getStyleForType(head) + headName);
 
                 String handleName = getAbilityNameForType(handle, 1);
-                if (!handleName.equals("") && handle != head) list.add(getStyleForType(handle) + handleName);
+                if (!handleName.isEmpty() && handle != head) list.add(getStyleForType(handle) + handleName);
 
                 if (getPartAmount() >= 3) {
                     String bindingName = getAbilityNameForType(binding, 2);
-                    if (!bindingName.equals("") && binding != head && binding != handle)
+                    if (!bindingName.isEmpty() && binding != head && binding != handle)
                         list.add(getStyleForType(binding) + bindingName);
                 }
 
                 if (getPartAmount() >= 4) {
                     String extraName = getAbilityNameForType(extra, 3);
-                    if (!extraName.equals("") && extra != head && extra != handle && extra != binding)
+                    if (!extraName.isEmpty() && extra != head && extra != handle && extra != binding)
                         list.add(getStyleForType(extra) + extraName);
                 }
 
                 int unbreaking = tags.getCompoundTag("InfiTool").getInteger("Unbreaking");
                 String reinforced = getReinforcedName(head, handle, binding, extra, unbreaking);
-                if (!reinforced.equals("")) list.add(reinforced);
+                if (!reinforced.isEmpty()) list.add(reinforced);
 
                 boolean displayToolTips = true;
                 int tipNum = 0;
@@ -315,7 +315,7 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
                     String tooltip = "Tooltip" + tipNum;
                     if (tags.getCompoundTag("InfiTool").hasKey(tooltip)) {
                         String tipName = tags.getCompoundTag("InfiTool").getString(tooltip);
-                        if (!tipName.equals("")) {
+                        if (!tipName.isEmpty()) {
                             // let's see if we can translate it somehow
                             // strip color information
                             String locString = "modifier.tooltip."
@@ -334,7 +334,7 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
         list.add("");
         int attack = (int) (tags.getCompoundTag("InfiTool").getInteger("Attack") * this.getDamageModifier());
         list.add(
-                "\u00A79+" + attack
+                EnumChatFormatting.BLUE.toString() + attack
                         + " "
                         + StatCollector.translateToLocalFormatted("attribute.name.generic.attackDamage"));
     }
@@ -344,7 +344,7 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
     }
 
     /**
-     * Returns the localized name of the materials ability. Only use this for display purposes, not for logic.
+     * Returns the localized name of the material's ability. Only use this for display purposes, not for logic.
      */
     public String getAbilityNameForType(int type, int part) {
         return TConstructRegistry.getMaterial(type).ability();
@@ -394,39 +394,18 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
     String getReinforcedString(int reinforced) {
         if (reinforced > 9) return StatCollector.translateToLocal("tool.unbreakable");
         String ret = StatCollector.translateToLocal("tool.reinforced") + " ";
-        switch (reinforced) {
-            case 1:
-                ret += "I";
-                break;
-            case 2:
-                ret += "II";
-                break;
-            case 3:
-                ret += "III";
-                break;
-            case 4:
-                ret += "IV";
-                break;
-            case 5:
-                ret += "V";
-                break;
-            case 6:
-                ret += "VI";
-                break;
-            case 7:
-                ret += "VII";
-                break;
-            case 8:
-                ret += "VIII";
-                break;
-            case 9:
-                ret += "IX";
-                break;
-            default:
-                ret += "X";
-                break;
-        }
-        return ret;
+        return switch (reinforced) {
+            case 1 -> ret + "I";
+            case 2 -> ret + "II";
+            case 3 -> ret + "III";
+            case 4 -> ret + "IV";
+            case 5 -> ret + "V";
+            case 6 -> ret + "VI";
+            case 7 -> ret + "VII";
+            case 8 -> ret + "VIII";
+            case 9 -> ret + "IX";
+            default -> ret + "X";
+        };
     }
 
     // Used for sounds and the like
@@ -435,15 +414,14 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
     /* Creative mode tools */
 
     @Override
-    public void getSubItems(Item id, CreativeTabs tab, List list) {
+    public void getSubItems(Item id, CreativeTabs tab, List<ItemStack> list) {
         for (Map.Entry<Integer, tconstruct.library.tools.ToolMaterial> integerToolMaterialEntry : TConstructRegistry.toolMaterials
                 .entrySet()) {
-            tconstruct.library.tools.ToolMaterial material = integerToolMaterialEntry.getValue();
             buildTool(integerToolMaterialEntry.getKey(), null, list);
         }
     }
 
-    public void buildTool(int id, String name, List list) {
+    public void buildTool(int id, String name, List<ItemStack> list) {
         Item accessory = getAccessoryItem();
         ItemStack accessoryStack = accessory != null ? new ItemStack(getAccessoryItem(), 1, id) : null;
         Item extra = getExtraItem();
@@ -566,17 +544,14 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
         if (tags != null) {
             tags = stack.getTagCompound().getCompoundTag("InfiTool");
             if (renderPass < getPartAmount()) {
-                switch (renderPass) {
-                    case 0:
-                        return getCorrectColor(stack, renderPass, tags, "Handle", handleIcons);
-                    case 1:
-                        return tags.getBoolean("Broken") ? getCorrectColor(stack, renderPass, tags, "Head", brokenIcons)
-                                : getCorrectColor(stack, renderPass, tags, "Head", headIcons);
-                    case 2:
-                        return getCorrectColor(stack, renderPass, tags, "Accessory", accessoryIcons);
-                    case 3:
-                        return getCorrectColor(stack, renderPass, tags, "Extra", extraIcons);
-                }
+                return switch (renderPass) {
+                    case 0 -> getCorrectColor(stack, renderPass, tags, "Handle", handleIcons);
+                    case 1 -> tags.getBoolean("Broken") ? getCorrectColor(stack, renderPass, tags, "Head", brokenIcons)
+                            : getCorrectColor(stack, renderPass, tags, "Head", headIcons);
+                    case 2 -> getCorrectColor(stack, renderPass, tags, "Accessory", accessoryIcons);
+                    case 3 -> getCorrectColor(stack, renderPass, tags, "Extra", extraIcons);
+                    default -> super.getColorFromItemStack(stack, renderPass);
+                };
             }
         }
         return super.getColorFromItemStack(stack, renderPass);
@@ -604,7 +579,6 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
 
     @Override
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
-        boolean used = false;
         int hotbarSlot = player.inventory.currentItem;
         int itemSlot = hotbarSlot == 0 ? 8 : hotbarSlot + 1;
         ItemStack nearbyStack;
@@ -637,18 +611,8 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
     }
 
     @Override
-    public boolean getIsRepairable(ItemStack par1ItemStack, ItemStack par2ItemStack) {
-        return false;
-    }
-
-    @Override
     public boolean isRepairable() {
         return false;
-    }
-
-    @Override
-    public int getItemEnchantability() {
-        return 0;
     }
 
     @Override

--- a/src/main/java/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/tconstruct/library/tools/ToolCore.java
@@ -334,7 +334,8 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
         list.add("");
         int attack = (int) (tags.getCompoundTag("InfiTool").getInteger("Attack") * this.getDamageModifier());
         list.add(
-                EnumChatFormatting.BLUE.toString() + "+" + attack
+                EnumChatFormatting.BLUE.toString() + "+"
+                        + attack
                         + " "
                         + StatCollector.translateToLocalFormatted("attribute.name.generic.attackDamage"));
     }

--- a/src/main/java/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/tconstruct/library/tools/ToolCore.java
@@ -394,18 +394,17 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
 
     String getReinforcedString(int reinforced) {
         if (reinforced > 9) return StatCollector.translateToLocal("tool.unbreakable");
-        String ret = StatCollector.translateToLocal("tool.reinforced") + " ";
-        return switch (reinforced) {
-            case 1 -> ret + "I";
-            case 2 -> ret + "II";
-            case 3 -> ret + "III";
-            case 4 -> ret + "IV";
-            case 5 -> ret + "V";
-            case 6 -> ret + "VI";
-            case 7 -> ret + "VII";
-            case 8 -> ret + "VIII";
-            case 9 -> ret + "IX";
-            default -> ret + "X";
+        return StatCollector.translateToLocal("tool.reinforced") + " " + switch (reinforced) {
+            case 1 -> "I";
+            case 2 -> "II";
+            case 3 -> "III";
+            case 4 -> "IV";
+            case 5 -> "V";
+            case 6 -> "VI";
+            case 7 -> "VII";
+            case 8 -> "VIII";
+            case 9 -> "IX";
+            default -> "X";
         };
     }
 

--- a/src/main/java/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/tconstruct/library/tools/ToolCore.java
@@ -334,7 +334,7 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
         list.add("");
         int attack = (int) (tags.getCompoundTag("InfiTool").getInteger("Attack") * this.getDamageModifier());
         list.add(
-                EnumChatFormatting.BLUE.toString() + attack
+                EnumChatFormatting.BLUE.toString() + "+" + attack
                         + " "
                         + StatCollector.translateToLocalFormatted("attribute.name.generic.attackDamage"));
     }

--- a/src/main/java/tconstruct/library/weaponry/AmmoItem.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoItem.java
@@ -90,8 +90,9 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
     }
 
     public boolean pickupAmmo(ItemStack stack, ItemStack candidate, EntityPlayer player) {
-        if (stack.getItem() == null || !stack.hasTagCompound() || !(stack.getItem() instanceof IAmmo pickedup))
+        if (stack.getItem() == null || !stack.hasTagCompound() || !(stack.getItem() instanceof IAmmo pickedup)) {
             return false;
+        }
 
         // check if our candidate fits
         if (candidate != null) {

--- a/src/main/java/tconstruct/library/weaponry/AmmoItem.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoItem.java
@@ -1,22 +1,36 @@
 package tconstruct.library.weaponry;
 
+import java.util.List;
+
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
+import baubles.api.expanded.IBaubleExpanded;
+import baubles.common.lib.PlayerHandler;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import mods.battlegear2.api.PlayerEventChild;
 import mods.battlegear2.api.weapons.IBattlegearWeapon;
+import tconstruct.TConstruct;
+import tconstruct.compat.LoadedMods;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.tools.TinkerTools;
 
 @Optional.InterfaceList({
-        @Optional.Interface(modid = "battlegear2", iface = "mods.battlegear2.api.weapons.IBattlegearWeapon") })
-public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IAmmo {
+        @Optional.Interface(modid = "battlegear2", iface = "mods.battlegear2.api.weapons.IBattlegearWeapon"),
+        @Optional.Interface(modid = "Baubles|Expanded", iface = "baubles.api.expanded.IBaubleExpanded"),
+        @Optional.Interface(modid = "Baubles", iface = "baubles.api.IBauble") })
+public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IAmmo, IBauble, IBaubleExpanded {
 
     public AmmoItem(int baseDamage, String name) {
         super(baseDamage);
@@ -76,33 +90,39 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
     }
 
     public boolean pickupAmmo(ItemStack stack, ItemStack candidate, EntityPlayer player) {
-        if (stack.getItem() == null || !stack.hasTagCompound() || !(stack.getItem() instanceof IAmmo)) return false;
+        if (stack.getItem() == null || !stack.hasTagCompound() || !(stack.getItem() instanceof IAmmo pickedup))
+            return false;
 
         // check if our candidate fits
         if (candidate != null) {
-            // same item
-            if (testIfAmmoMatches(stack, candidate)) {
-                IAmmo pickedup = ((IAmmo) stack.getItem());
-                IAmmo ininventory = ((IAmmo) candidate.getItem());
-                // we can be sure that it's ammo, since stack is ammo and they're equal
-                int count = pickedup.getAmmoCount(stack);
-                if (count != ininventory.addAmmo(count, candidate)) return true;
-            }
+            if (ammoCanStack(stack, pickedup, candidate)) return true;
         }
 
-        // search the players inventory
+        // search the player's inventory
         for (ItemStack invItem : player.inventory.mainInventory) {
-            if (testIfAmmoMatches(stack, invItem)) {
-                IAmmo pickedup = ((IAmmo) stack.getItem());
-                IAmmo ininventory = ((IAmmo) invItem.getItem());
-                // we can be sure that it's ammo, since stack is ammo and they're equal
-                int count = pickedup.getAmmoCount(stack);
-                if (count != ininventory.addAmmo(count, invItem)) return true;
+            if (ammoCanStack(stack, pickedup, invItem)) return true;
+        }
+
+        // search bauble slots
+        if (LoadedMods.baubles) {
+            for (ItemStack bauble : PlayerHandler.getPlayerBaubles(player).stackList) {
+                if (ammoCanStack(stack, pickedup, bauble)) return true;
             }
         }
 
         // couldn't find a matching thing.
         return false;
+    }
+
+    private boolean ammoCanStack(ItemStack stack, IAmmo pickedup, ItemStack bauble) {
+        if (!testIfAmmoMatches(stack, bauble)) {
+            return false;
+        }
+
+        IAmmo ininventory = ((IAmmo) bauble.getItem());
+        // we can be sure that it's ammo, since stack is ammo and they're equal
+        int count = pickedup.getAmmoCount(stack);
+        return count != ininventory.addAmmo(count, bauble);
     }
 
     private boolean testIfAmmoMatches(ItemStack reference, ItemStack candidate) {
@@ -197,5 +217,63 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
         return (mainhand != null && mainhand.getItem() != TinkerTools.cleaver
                 && mainhand.getItem() != TinkerTools.battleaxe)
                 && (offhand.getItem() != TinkerTools.cleaver && offhand.getItem() != TinkerTools.battleaxe);
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles|Expanded")
+    public String[] getBaubleTypes(ItemStack itemstack) {
+        return new String[] { TConstruct.AMMOBAUBLESLOT };
+    }
+
+    // Fallback for base Baubles
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public BaubleType getBaubleType(ItemStack itemStack) {
+        return BaubleType.RING;
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public void onWornTick(ItemStack itemstack, EntityLivingBase player) {
+        onUpdate(itemstack, player.worldObj, player, 0, false);
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public void onEquipped(ItemStack itemstack, EntityLivingBase player) {}
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
+        return true;
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
+        return true;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack stack, EntityPlayer player, List<String> lines, boolean advanced) {
+        super.addInformation(stack, player, lines, advanced);
+        addBaubleInformation(lines);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Optional.Method(modid = "Baubles")
+    private void addBaubleInformation(List<String> lines) {
+        if (LoadedMods.baublesExpanded) {
+            if (GuiScreen.isShiftKeyDown()) {
+                lines.add(StatCollector.translateToLocal("tooltip.compatibleslots"));
+                lines.add(StatCollector.translateToLocal("slot.quiver"));
+                if (LoadedMods.tiCTooltips) lines.add(""); // Required for spacing
+            } else if (!LoadedMods.tiCTooltips) lines.add(StatCollector.translateToLocal("tooltip.shiftprompt"));
+        } else lines.add(StatCollector.translateToLocal("baubletype.any"));
     }
 }

--- a/src/main/java/tconstruct/library/weaponry/AmmoItem.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoItem.java
@@ -96,18 +96,18 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
 
         // check if our candidate fits
         if (candidate != null) {
-            if (ammoCanStack(stack, pickedup, candidate)) return true;
+            if (tryStackAmmo(stack, pickedup, candidate)) return true;
         }
 
         // search the player's inventory
         for (ItemStack invItem : player.inventory.mainInventory) {
-            if (ammoCanStack(stack, pickedup, invItem)) return true;
+            if (tryStackAmmo(stack, pickedup, invItem)) return true;
         }
 
         // search bauble slots
         if (LoadedMods.baubles) {
             for (ItemStack bauble : PlayerHandler.getPlayerBaubles(player).stackList) {
-                if (ammoCanStack(stack, pickedup, bauble)) return true;
+                if (tryStackAmmo(stack, pickedup, bauble)) return true;
             }
         }
 
@@ -115,7 +115,7 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
         return false;
     }
 
-    private boolean ammoCanStack(ItemStack stack, IAmmo pickedup, ItemStack bauble) {
+    private boolean tryStackAmmo(ItemStack stack, IAmmo pickedup, ItemStack bauble) {
         if (!testIfAmmoMatches(stack, bauble)) {
             return false;
         }
@@ -274,7 +274,11 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
                 lines.add(StatCollector.translateToLocal("tooltip.compatibleslots"));
                 lines.add(StatCollector.translateToLocal("slot.quiver"));
                 if (LoadedMods.tiCTooltips) lines.add(""); // Required for spacing
-            } else if (!LoadedMods.tiCTooltips) lines.add(StatCollector.translateToLocal("tooltip.shiftprompt"));
-        } else lines.add(StatCollector.translateToLocal("baubletype.any"));
+            } else if (!LoadedMods.tiCTooltips) {
+                lines.add(StatCollector.translateToLocal("tooltip.shiftprompt"));
+            }
+        } else {
+            lines.add(StatCollector.translateToLocal("baubletype.any"));
+        }
     }
 }

--- a/src/main/java/tconstruct/library/weaponry/AmmoItem.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoItem.java
@@ -262,7 +262,7 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack stack, EntityPlayer player, List<String> lines, boolean advanced) {
         super.addInformation(stack, player, lines, advanced);
-        addBaubleInformation(lines);
+        if (LoadedMods.baubles) addBaubleInformation(lines);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/tconstruct/library/weaponry/AmmoItem.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoItem.java
@@ -2,7 +2,6 @@ package tconstruct.library.weaponry;
 
 import java.util.List;
 
-import baubles.api.expanded.BaubleExpandedSlots;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -14,6 +13,7 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
 import baubles.api.BaubleType;
 import baubles.api.IBauble;
+import baubles.api.expanded.BaubleExpandedSlots;
 import baubles.api.expanded.IBaubleExpanded;
 import baubles.common.lib.PlayerHandler;
 import cpw.mods.fml.common.Optional;
@@ -21,7 +21,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import mods.battlegear2.api.PlayerEventChild;
 import mods.battlegear2.api.weapons.IBattlegearWeapon;
-import tconstruct.TConstruct;
 import tconstruct.compat.LoadedMods;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.ToolCore;

--- a/src/main/java/tconstruct/library/weaponry/AmmoItem.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoItem.java
@@ -2,6 +2,7 @@ package tconstruct.library.weaponry;
 
 import java.util.List;
 
+import baubles.api.expanded.BaubleExpandedSlots;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -222,7 +223,7 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
     @Override
     @Optional.Method(modid = "Baubles|Expanded")
     public String[] getBaubleTypes(ItemStack itemstack) {
-        return new String[] { TConstruct.AMMOBAUBLESLOT };
+        return new String[] { BaubleExpandedSlots.quiverType };
     }
 
     // Fallback for base Baubles

--- a/src/main/java/tconstruct/library/weaponry/BowBaseAmmo.java
+++ b/src/main/java/tconstruct/library/weaponry/BowBaseAmmo.java
@@ -72,7 +72,7 @@ public abstract class BowBaseAmmo extends ProjectileWeapon {
 
         if (LoadedMods.baubles) {
             for (ItemStack bauble : PlayerHandler.getPlayerBaubles(player).stackList) {
-                if (checkTinkerArrow(bauble) || checkVanillaArrow(bauble)) {
+                if (checkTinkerArrow(bauble)) {
                     return bauble;
                 }
             }

--- a/src/main/java/tconstruct/library/weaponry/BowBaseAmmo.java
+++ b/src/main/java/tconstruct/library/weaponry/BowBaseAmmo.java
@@ -12,9 +12,10 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import cpw.mods.fml.common.Loader;
+import baubles.common.lib.PlayerHandler;
 import mods.battlegear2.api.core.IBattlePlayer;
 import tconstruct.compat.Battlegear2Compat;
+import tconstruct.compat.LoadedMods;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.tools.BowstringMaterial;
@@ -23,8 +24,6 @@ import tconstruct.weaponry.ammo.ArrowAmmo;
 import tconstruct.weaponry.entity.ArrowEntity;
 
 public abstract class BowBaseAmmo extends ProjectileWeapon {
-
-    private static final boolean isBattlegear2Loaded = Loader.isModLoaded("battlegear2");
 
     public BowBaseAmmo(int baseDamage, String name) {
         super(baseDamage, name);
@@ -62,12 +61,20 @@ public abstract class BowBaseAmmo extends ProjectileWeapon {
 
     @Override
     public ItemStack searchForAmmo(EntityPlayer player, ItemStack weapon) {
-        // arrow priority: hotbar > inventory, tinker arrows > regular arrows
-        if (isBattlegear2Loaded && player instanceof IBattlePlayer battlePlayer
+        // arrow priority: offhand > bauble slots > hotbar > inventory, tinker arrows > regular arrows
+        if (LoadedMods.battlegear2 && player instanceof IBattlePlayer battlePlayer
                 && battlePlayer.battlegear2$isBattlemode()) {
             ItemStack offhand = Battlegear2Compat.getBattlegear2Offhand(player);
             if (checkTinkerArrow(offhand) || checkVanillaArrow(offhand)) {
                 return offhand;
+            }
+        }
+
+        if (LoadedMods.baubles) {
+            for (ItemStack bauble : PlayerHandler.getPlayerBaubles(player).stackList) {
+                if (checkTinkerArrow(bauble) || checkVanillaArrow(bauble)) {
+                    return bauble;
+                }
             }
         }
 
@@ -142,7 +149,7 @@ public abstract class BowBaseAmmo extends ProjectileWeapon {
     }
 
     @Override
-    public void buildTool(int id, String name, List list) {
+    public void buildTool(int id, String name, List<ItemStack> list) {
         // does the material have a bow material?
         if (TConstructRegistry.getBowMaterial(id) == null) return;
 

--- a/src/main/java/tconstruct/library/weaponry/ProjectileWeapon.java
+++ b/src/main/java/tconstruct/library/weaponry/ProjectileWeapon.java
@@ -198,7 +198,7 @@ public abstract class ProjectileWeapon extends ToolCore implements IBattlegearWe
         playFiringSound(world, player, weapon, ammo, projectileSpeed, accuracy);
 
         // use up ammo
-        if (!player.capabilities.isCreativeMode) {
+        if (!player.capabilities.isCreativeMode && !world.isRemote) {
             if (ammo.getItem() instanceof IAmmo) {
                 if (ammo.hasTagCompound()) {
                     int ammoReinforced = ammo.getTagCompound().getCompoundTag("InfiTool").getInteger("Unbreaking");

--- a/src/main/java/tconstruct/weaponry/ammo/ArrowAmmo.java
+++ b/src/main/java/tconstruct/weaponry/ammo/ArrowAmmo.java
@@ -5,6 +5,7 @@ import java.util.List;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 
 import tconstruct.TConstruct;
@@ -27,18 +28,13 @@ public class ArrowAmmo extends AmmoItem {
 
     @Override
     public String getIconSuffix(int partType) {
-        switch (partType) {
-            case 0:
-                return "_arrow_head";
-            case 1:
-                return ""; // Doesn't break
-            case 2:
-                return "_arrow_shaft";
-            case 3:
-                return "_arrow_fletching";
-            default:
-                return "";
-        }
+        return switch (partType) {
+            case 0 -> "_arrow_head";
+            case 1 -> ""; // Doesn't break
+            case 2 -> "_arrow_shaft";
+            case 3 -> "_arrow_fletching";
+            default -> "";
+        };
     }
 
     @Override
@@ -89,7 +85,7 @@ public class ArrowAmmo extends AmmoItem {
     }
 
     @Override
-    public void buildTool(int id, String name, List list) {
+    public void buildTool(int id, String name, List<ItemStack> list) {
         if (TConstructRegistry.getArrowMaterial(id) == null) return;
 
         ItemStack handleStack = new ItemStack(getHandleItem(), 1, 0); // wooden shaft
@@ -104,7 +100,7 @@ public class ArrowAmmo extends AmmoItem {
     }
 
     @Override
-    public void getSubItems(Item id, CreativeTabs tab, List list) {
+    public void getSubItems(Item id, CreativeTabs tab, List<ItemStack> list) {
         super.getSubItems(id, tab, list);
 
         // vanilla arrow
@@ -134,9 +130,9 @@ public class ArrowAmmo extends AmmoItem {
     @Override
     public String getAbilityNameForType(int type, int part) {
         // blaze shaft?
-        if (part == 1 && type == 3) return "\u00a76" + StatCollector.translateToLocal("modifier.tool.blaze");
-        if (part >= 1) // only head has ability otherwise
-            return "";
+        if (part == 1 && type == 3)
+            return EnumChatFormatting.GOLD + StatCollector.translateToLocal("modifier.tool.blaze");
+        if (part > 1) return ""; // only head has ability otherwise
         return super.getAbilityNameForType(type, part);
     }
 }

--- a/src/main/java/tconstruct/weaponry/ammo/BoltAmmo.java
+++ b/src/main/java/tconstruct/weaponry/ammo/BoltAmmo.java
@@ -23,18 +23,13 @@ public class BoltAmmo extends AmmoItem {
 
     @Override
     public String getIconSuffix(int partType) {
-        switch (partType) {
-            case 0:
-                return "_bolt_head";
-            case 1:
-                return ""; // Doesn't break
-            case 2:
-                return "_bolt_shaft";
-            case 3:
-                return "_bolt_fletching";
-            default:
-                return "";
-        }
+        return switch (partType) {
+            case 0 -> "_bolt_head";
+            case 1 -> ""; // Doesn't break
+            case 2 -> "_bolt_shaft";
+            case 3 -> "_bolt_fletching";
+            default -> "";
+        };
     }
 
     @Override
@@ -79,7 +74,7 @@ public class BoltAmmo extends AmmoItem {
     }
 
     @Override
-    public void buildTool(int id, String name, List list) {
+    public void buildTool(int id, String name, List<ItemStack> list) {
         if (TConstructRegistry.getArrowMaterial(id) == null) return;
 
         // dual material head: we use wooden shafts

--- a/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
+++ b/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
@@ -68,8 +68,8 @@ public class Crossbow extends ProjectileWeapon {
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
         NBTTagCompound tags = stack.getTagCompound().getCompoundTag("InfiTool");
 
-        // unload on shift-rightclick
-        if (player.isSneaking()) if (unload(stack, player, tags)) return stack;
+        // unload on sneak right-click
+        if (player.isSneaking() && unload(stack, player, tags)) return stack;
 
         // loaded
         if (tags.getBoolean("Loaded")) fire(stack, world, player);
@@ -94,8 +94,9 @@ public class Crossbow extends ProjectileWeapon {
         if (tags.hasKey("Reloading")) {
             int timeLeft = tags.getInteger("Reloading");
             timeLeft--;
-            if (timeLeft > 0) tags.setInteger("Reloading", timeLeft);
-            else {
+            if (timeLeft > 0) {
+                tags.setInteger("Reloading", timeLeft);
+            } else {
                 tags.removeTag("Reloading");
                 reload(stack, player, world, tags);
             }
@@ -106,20 +107,20 @@ public class Crossbow extends ProjectileWeapon {
     public float getWindupProgress(ItemStack itemStack, EntityPlayer player) {
         NBTTagCompound tags = itemStack.getTagCompound().getCompoundTag("InfiTool");
 
-        // loaded, full accuracy
-        if (tags.getBoolean("Loaded")) return 1.0f;
-        // not loaded, but reloading -> progress
-        else if (tags.hasKey("Reloading"))
+        if (tags.getBoolean("Loaded")) { // loaded, full accuracy
+            return 1.0f;
+        } else if (tags.hasKey("Reloading")) { // not loaded, but reloading -> progress
             return 1.0f - ((float) tags.getInteger("Reloading")) / ((float) getWindupTime(itemStack));
-        // not loaded and not reloading -> no accuracy!
-        else return 0.0f;
+        } else { // not loaded and not reloading -> no accuracy!
+            return 0.0f;
+        }
     }
 
     public void initiateReload(ItemStack stack, EntityPlayer player, NBTTagCompound tags) {
         if (tags.getBoolean("Broken")) return;
 
         // has ammo?
-        if (searchForAmmo(player, stack) != null) if (!tags.hasKey("Reloading"))
+        if (searchForAmmo(player, stack) != null && !tags.hasKey("Reloading"))
             // start reloading
             tags.setInteger("Reloading", getWindupTime(stack));
     }
@@ -150,7 +151,9 @@ public class Crossbow extends ProjectileWeapon {
                     int ammoReinforced = ammo.getTagCompound().getCompoundTag("InfiTool").getInteger("Unbreaking");
                     if (random.nextInt(10) < 10 - ammoReinforced) ammoItem.consumeAmmo(1, ammo);
                 }
-            } else player.inventory.consumeInventoryItem(ammo.getItem());
+            } else {
+                player.inventory.consumeInventoryItem(ammo.getItem());
+            }
         }
 
         playReloadSound(world, player, weapon, ammo);
@@ -325,7 +328,6 @@ public class Crossbow extends ProjectileWeapon {
             case 3 -> getCorrectAnimationIcon(animationExtraIcons, tags.getInteger("RenderExtra"), progress);
             default -> emptyIcon;
         };
-
     }
 
     @Override

--- a/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
+++ b/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
@@ -11,9 +11,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
-import cpw.mods.fml.common.Loader;
+import baubles.common.lib.PlayerHandler;
 import mods.battlegear2.api.core.IBattlePlayer;
 import tconstruct.compat.Battlegear2Compat;
+import tconstruct.compat.LoadedMods;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.tools.AbilityHelper;
@@ -27,8 +28,6 @@ import tconstruct.weaponry.ammo.BoltAmmo;
 import tconstruct.weaponry.entity.BoltEntity;
 
 public class Crossbow extends ProjectileWeapon {
-
-    private static final boolean isBattlegear2Loaded = Loader.isModLoaded("battlegear2");
 
     public Crossbow() {
         super(0, "Crossbow");
@@ -87,9 +86,8 @@ public class Crossbow extends ProjectileWeapon {
 
         if (!stack.hasTagCompound()) return;
 
-        if (!(entity instanceof EntityPlayer)) return;
+        if (!(entity instanceof EntityPlayer player)) return;
 
-        EntityPlayer player = (EntityPlayer) entity;
         if (player.inventory.getCurrentItem() != stack) return;
 
         NBTTagCompound tags = stack.getTagCompound().getCompoundTag("InfiTool");
@@ -146,13 +144,13 @@ public class Crossbow extends ProjectileWeapon {
         tags.setBoolean("Loaded", true);
 
         // remove loaded item
-        if (ammo.getItem() instanceof IAmmo) {
-            if (ammo.hasTagCompound()) {
-                int ammoReinforced = ammo.getTagCompound().getCompoundTag("InfiTool").getInteger("Unbreaking");
-                if (random.nextInt(10) < 10 - ammoReinforced) ((IAmmo) ammo.getItem()).consumeAmmo(1, ammo);
-            }
-        } else {
-            player.inventory.consumeInventoryItem(ammo.getItem());
+        if (!world.isRemote) {
+            if (ammo.getItem() instanceof IAmmo) {
+                if (ammo.hasTagCompound()) {
+                    int ammoReinforced = ammo.getTagCompound().getCompoundTag("InfiTool").getInteger("Unbreaking");
+                    if (random.nextInt(10) < 10 - ammoReinforced) ((IAmmo) ammo.getItem()).consumeAmmo(1, ammo);
+                }
+            } else player.inventory.consumeInventoryItem(ammo.getItem());
         }
 
         playReloadSound(world, player, weapon, ammo);
@@ -224,30 +222,34 @@ public class Crossbow extends ProjectileWeapon {
 
     @Override
     public ItemStack searchForAmmo(EntityPlayer player, ItemStack weapon) {
-        // arrow priority: hotbar > inventory, tinker arrows > regular arrows
-        if (isBattlegear2Loaded && player instanceof IBattlePlayer battlePlayer
+        // bolt priority: offhand > bauble slots > hotbar > inventory
+        if (LoadedMods.battlegear2 && player instanceof IBattlePlayer battlePlayer
                 && battlePlayer.battlegear2$isBattlemode()) {
             ItemStack offhand = Battlegear2Compat.getBattlegear2Offhand(player);
-            if (offhand != null && (offhand.getItem() instanceof BoltAmmo)
-                    && ((IAmmo) offhand.getItem()).getAmmoCount(offhand) > 0) {
-                return offhand;
+            if (checkTinkerBolt(offhand)) return offhand;
+        }
+
+        if (LoadedMods.baubles) {
+            for (ItemStack bauble : PlayerHandler.getPlayerBaubles(player).stackList) {
+                if (checkTinkerBolt(bauble)) return bauble;
             }
         }
 
         ItemStack[] inventory = player.inventory.mainInventory;
 
-        // check hotbar for tinker arrows
+        // check hotbar for bolts
         for (ItemStack stack : inventory) {
-            if (stack == null) continue;
-            if (!(stack.getItem() instanceof BoltAmmo)) continue;
-            if (((IAmmo) stack.getItem()).getAmmoCount(stack) <= 0) continue;
-            return stack;
+            if (checkTinkerBolt(stack)) return stack;
         }
 
         if (player.capabilities.isCreativeMode && TinkerWeaponry.creativeBolt != null)
             return TinkerWeaponry.creativeBolt.copy();
 
         return null;
+    }
+
+    private static boolean checkTinkerBolt(ItemStack stack) {
+        return stack != null && (stack.getItem() instanceof BoltAmmo bolt) && bolt.getAmmoCount(stack) > 0;
     }
 
     @Override
@@ -316,36 +318,26 @@ public class Crossbow extends ProjectileWeapon {
         }
 
         // get the correct icon
-        switch (renderPass) {
-            case 0:
-                return getCorrectAnimationIcon(animationHandleIcons, tags.getInteger("RenderHandle"), progress);
-            case 1:
-                return getCorrectAnimationIcon(animationHeadIcons, tags.getInteger("RenderHead"), progress);
-            case 2:
-                return getCorrectAnimationIcon(animationAccessoryIcons, tags.getInteger("RenderAccessory"), progress);
-            case 3:
-                return getCorrectAnimationIcon(animationExtraIcons, tags.getInteger("RenderExtra"), progress);
-        }
+        return switch (renderPass) {
+            case 0 -> getCorrectAnimationIcon(animationHandleIcons, tags.getInteger("RenderHandle"), progress);
+            case 1 -> getCorrectAnimationIcon(animationHeadIcons, tags.getInteger("RenderHead"), progress);
+            case 2 -> getCorrectAnimationIcon(animationAccessoryIcons, tags.getInteger("RenderAccessory"), progress);
+            case 3 -> getCorrectAnimationIcon(animationExtraIcons, tags.getInteger("RenderExtra"), progress);
+            default -> emptyIcon;
+        };
 
-        return emptyIcon;
     }
 
     @Override
     public String getIconSuffix(int partType) {
-        switch (partType) {
-            case 0:
-                return "_crossbow_bow"; // head
-            case 1:
-                return ""; // broken
-            case 2:
-                return "_crossbow_body"; // handle
-            case 3:
-                return "_crossbow_string"; // accessory
-            case 4:
-                return "_crossbow_binding"; // extra
-            default:
-                return "";
-        }
+        return switch (partType) {
+            case 0 -> "_crossbow_bow"; // head
+            case 1 -> ""; // broken
+            case 2 -> "_crossbow_body"; // handle
+            case 3 -> "_crossbow_string"; // accessory
+            case 4 -> "_crossbow_binding"; // extra
+            default -> "";
+        };
     }
 
     @Override
@@ -394,7 +386,7 @@ public class Crossbow extends ProjectileWeapon {
     }
 
     @Override
-    public void buildTool(int id, String name, List list) {
+    public void buildTool(int id, String name, List<ItemStack> list) {
         // does the material have a bow material?
         if (TConstructRegistry.getBowMaterial(id) == null) return;
 
@@ -418,14 +410,11 @@ public class Crossbow extends ProjectileWeapon {
         // bowstring: custom material -> custom coloring
         // todo: move this into the custom material itself
         int mat = stack.getTagCompound().getCompoundTag("InfiTool").getInteger("Accessory");
-        switch (mat) {
-            case 0:
-                return 0xffffffff; // string = white
-            case 1:
-                return 0xffccccff; // macig string = light blue
-            case 2:
-                return 0xffffcccc; // flamestring = light red
-        }
-        return super.getColorFromItemStack(stack, renderPass);
+        return switch (mat) {
+            case 0 -> 0xffffffff; // string = white
+            case 1 -> 0xffccccff; // magic string = light blue
+            case 2 -> 0xffffcccc; // flamestring = light red
+            default -> super.getColorFromItemStack(stack, renderPass);
+        };
     }
 }

--- a/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
+++ b/src/main/java/tconstruct/weaponry/weapons/Crossbow.java
@@ -145,10 +145,10 @@ public class Crossbow extends ProjectileWeapon {
 
         // remove loaded item
         if (!world.isRemote) {
-            if (ammo.getItem() instanceof IAmmo) {
+            if (ammo.getItem() instanceof IAmmo ammoItem) {
                 if (ammo.hasTagCompound()) {
                     int ammoReinforced = ammo.getTagCompound().getCompoundTag("InfiTool").getInteger("Unbreaking");
-                    if (random.nextInt(10) < 10 - ammoReinforced) ((IAmmo) ammo.getItem()).consumeAmmo(1, ammo);
+                    if (random.nextInt(10) < 10 - ammoReinforced) ammoItem.consumeAmmo(1, ammo);
                 }
             } else player.inventory.consumeInventoryItem(ammo.getItem());
         }

--- a/src/main/java/tconstruct/weaponry/weapons/LongBow.java
+++ b/src/main/java/tconstruct/weaponry/weapons/LongBow.java
@@ -37,7 +37,7 @@ public class LongBow extends BowBaseAmmo {
     protected Entity createProjectile(ItemStack arrows, World world, EntityPlayer player, float speed, float accuracy,
             float windup) {
         if (arrows.getItem() instanceof ArrowAmmo) {
-            // modify accuraccy of the arrow depending on its accuraccy and weight
+            // modify accuracy of the arrow depending on its accuracy and weight
             NBTTagCompound tags = arrows.getTagCompound().getCompoundTag("InfiTool");
             float matAccuracy = tags.getFloat("Accuracy");
             float weight = tags.getFloat("Mass");
@@ -52,20 +52,14 @@ public class LongBow extends BowBaseAmmo {
 
     @Override
     public String getIconSuffix(int partType) {
-        switch (partType) {
-            case 0:
-                return "_bow_top";
-            case 1:
-                return "_bowstring_broken";
-            case 2:
-                return "_bowstring";
-            case 3:
-                return "_bow_bottom";
-            case 4:
-                return "_bow_grip";
-            default:
-                return "";
-        }
+        return switch (partType) {
+            case 0 -> "_bow_top";
+            case 1 -> "_bowstring_broken";
+            case 2 -> "_bowstring";
+            case 3 -> "_bow_bottom";
+            case 4 -> "_bow_grip";
+            default -> "";
+        };
     }
 
     @Override

--- a/src/main/java/tconstruct/weaponry/weapons/ShortBow.java
+++ b/src/main/java/tconstruct/weaponry/weapons/ShortBow.java
@@ -34,7 +34,7 @@ public class ShortBow extends BowBaseAmmo {
     protected Entity createProjectile(ItemStack arrows, World world, EntityPlayer player, float speed, float accuracy,
             float windup) {
         if (arrows.getItem() instanceof ArrowAmmo) {
-            // modify accuraccy of the arrow depending on its accuraccy and weight
+            // modify accuracy of the arrow depending on its accuracy and weight
             NBTTagCompound tags = arrows.getTagCompound().getCompoundTag("InfiTool");
             float matAccuracy = tags.getFloat("Accuracy");
             float weight = tags.getFloat("Mass");
@@ -49,18 +49,13 @@ public class ShortBow extends BowBaseAmmo {
 
     @Override
     public String getIconSuffix(int partType) {
-        switch (partType) {
-            case 0:
-                return "_bow_top";
-            case 1:
-                return "_bowstring_broken";
-            case 2:
-                return "_bowstring";
-            case 3:
-                return "_bow_bottom";
-            default:
-                return "";
-        }
+        return switch (partType) {
+            case 0 -> "_bow_top";
+            case 1 -> "_bowstring_broken";
+            case 2 -> "_bowstring";
+            case 3 -> "_bow_bottom";
+            default -> "";
+        };
     }
 
     @Override
@@ -71,11 +66,6 @@ public class ShortBow extends BowBaseAmmo {
     @Override
     public String getDefaultFolder() {
         return "shortbow";
-    }
-
-    @Override
-    public int getPartAmount() {
-        return 3;
     }
 
     @Override
@@ -103,8 +93,7 @@ public class ShortBow extends BowBaseAmmo {
     public void onUpdate(ItemStack stack, World world, Entity entity, int par4, boolean par5) {
         // shortbows are smaller and more mobile than longbows
         super.onUpdate(stack, world, entity, par4, par5);
-        if (entity instanceof EntityPlayerSP) {
-            EntityPlayerSP player = (EntityPlayerSP) entity;
+        if (entity instanceof EntityPlayerSP player) {
             ItemStack usingItem = player.getItemInUse();
             if (usingItem != null && usingItem.getItem() == this) {
                 player.movementInput.moveForward *= 1.5F;

--- a/src/main/resources/assets/tinker/lang/en_US.lang
+++ b/src/main/resources/assets/tinker/lang/en_US.lang
@@ -1204,3 +1204,5 @@ fluid.molten.bedrockiumIngots=Molten Bedrockium Ingots
 tconstruct.mobsinfocompat.tinkers_construct_beheading=Each level of beheading on your weapon gives additional %.2f%%
 tconstruct.mobsinfocompat.tinkers_construct_beheading_1=If you are using a Cleaver, it gives another %.2f%%
 
+#Baubles compat (Baubles Expanded already has the relevant localizations)
+baubletype.any=Equippable in a §aRing§7 slot


### PR DESCRIPTION
Since the Battlegear slots were removed, the inventory is even more cramped than ever before. This will help that a little bit by allowing arrows* and bolts to be used from a bauble slot.

Register a Quiver slot for ammo if Baubles Expanded is present. They can be put in a Ring slot instead (had to pick one) if just Baubles is present. Modifiers with effects like Moss and picking up ammo works while in a bauble slot.
Add info to the tooltip about the valid slot.
Clean up some unused and outdated logic in all the bow and ammo classes (improved switch statements, using EnumChatFormatting, removing unused variables, pattern variables, etc).

*~~Just TiCon arrows can be put in the slots for now, but bows can also use vanilla arrows. I will probably PR Hodgepodge to mixin vanilla ones, but support for that is good here already because the logic is the same as regular slots.~~ Bauble slots only allow a stack size of 1 and this isn't even really worth it.