### PR TITLE
Make mouse button keybinds more reliable

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,10 @@
 // Add your dependencies here
 
 dependencies {
-    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta54:api')
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta55:api')
     api("com.github.GTNewHorizons:Mantle:0.5.1:dev")
     api("com.github.GTNewHorizons:ForgeMultipart:1.6.8:dev")
-    implementation("com.github.GTNewHorizons:NotEnoughItems:2.7.72-GTNH:dev")
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.7.77-GTNH:dev")
     compileOnlyApi("curse.maven:cofh-core-69162:2388751")
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:api")
     compileOnly("com.github.GTNewHorizons:waila:1.8.12:api")
@@ -17,7 +17,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Mobs-Info:0.5.4-GTNH:dev")
     compileOnlyApi("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     compileOnlyApi("com.github.GTNewHorizons:Natura:2.8.8:dev")
-    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH:dev')
+    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.13-GTNH:dev')
 
     // For testing scythe crop harvesting
     // devOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")

--- a/src/main/java/tconstruct/client/ArmorControls.java
+++ b/src/main/java/tconstruct/client/ArmorControls.java
@@ -15,6 +15,7 @@ import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent;
+import cpw.mods.fml.common.gameevent.InputEvent.MouseInputEvent;
 import mantle.common.network.AbstractPacket;
 import modwarriors.notenoughkeys.api.Api;
 import modwarriors.notenoughkeys.api.KeyBindingPressedEvent;
@@ -88,6 +89,13 @@ public class ArmorControls {
         if (!isNotEnoughKeysLoaded) {
             checkAndPerformKeyActions(null, false);
         }
+    }
+
+    /**
+     * handles keybinds on mouse buttons
+     */
+    public void mouseEvent(MouseInputEvent event) {
+        checkAndPerformKeyActions(null, false);
     }
 
     @Optional.Method(modid = "notenoughkeys")
@@ -217,6 +225,11 @@ public class ArmorControls {
         @SubscribeEvent
         public void keyEventWrapper(KeyInputEvent event) {
             ArmorControls.this.keyEvent(event);
+        }
+
+        @SubscribeEvent
+        public void mouseEventWrapper(MouseInputEvent event) {
+            ArmorControls.this.mouseEvent(event);
         }
 
         @Optional.Method(modid = "notenoughkeys")


### PR DESCRIPTION
While Minecraft allows configuring keybinds on mouse buttons, handling them needs explicit support in each mod. This additionally subscribes to `MouseInputEvent` to check if a button on there has been pressed).

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20978