### PR TITLE
Don't auto connect redstone traces to Faucets

### DIFF
--- a/src/main/java/tconstruct/smeltery/blocks/SearedBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/SearedBlock.java
@@ -239,12 +239,6 @@ public class SearedBlock extends InventoryBlock {
         return super.getCollisionBoundingBoxFromPool(world, x, y, z);
     }
 
-    /* Redstone */
-    @Override
-    public boolean canConnectRedstone(IBlockAccess world, int x, int y, int z, int side) {
-        return world.getBlockMetadata(x, y, z) == 1;
-    }
-
     @Override
     public void onNeighborBlockChange(World world, int x, int y, int z, Block neighborBlockID) {
         if (world.getBlockMetadata(x, y, z) == 1) {


### PR DESCRIPTION
`Block#canConnectRedstone` which makes redstone powder traces automatically point towards components is more meant for redstone sources. To quote the MC wiki (as I'm too lazy to find the relevant source code):

> Redstone wire does not automatically configure itself to point toward _mechanism components_; the only exceptions are the back and side faces of pistons and sticky pistons in Bedrock Edition. If such a configuration is desired, the other neighbors of the redstone wire must be arranged to create it, i.e the redstone dust must be placed in a way that it would be pointed at the block’s location even if it were not there.

The wiki describes 3 basic redstone components: power, transmission, and mechanism components, of which the Faucet is the latter. And this is how the Faucet already behaves, implementing `canConnectRedstone` just added some visual confusion.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21138