### PR TITLE
fix(ProjectileBase): prevent projectile reversal in water

### DIFF
--- a/src/main/java/tconstruct/library/entity/ProjectileBase.java
+++ b/src/main/java/tconstruct/library/entity/ProjectileBase.java
@@ -501,8 +501,8 @@ public abstract class ProjectileBase extends EntityArrow implements IEntityAddit
                         this.motionZ);
             }
 
-            // more slowdown in water
-            slowdown = 1d - 20d * getSlowdown();
+            // more slowdown in water, clamped at 0 to prevent reversal
+            slowdown = Math.max(0, 1d - 20d * getSlowdown());
         }
 
         // phshshshshshs


### PR DESCRIPTION
Shurikens would reverse direction at high speed when entering water horizontally, that resulted in a negative motion multiplier from slowdown.

Fix GTNewHorizons/GT-New-Horizons-Modpack#16870, it will prevent the negative motion multiplier, but it's still possible to hurt yourself throwing shurikens in water, above you, but logically this time, as they will slow down further away from you and then come back at you slowly, which is quite realistic