### PR TITLE
fix: consume vanilla arrows instead of duplicating them

### DIFF
--- a/src/main/java/tconstruct/library/weaponry/ProjectileWeapon.java
+++ b/src/main/java/tconstruct/library/weaponry/ProjectileWeapon.java
@@ -200,10 +200,14 @@ public abstract class ProjectileWeapon extends ToolCore implements IBattlegearWe
         // use up ammo
         if (!player.capabilities.isCreativeMode && !world.isRemote) {
             if (ammo.getItem() instanceof IAmmo) {
+                // if we're dealing with tinkers ammo, handle their custom logic
                 if (ammo.hasTagCompound()) {
                     int ammoReinforced = ammo.getTagCompound().getCompoundTag("InfiTool").getInteger("Unbreaking");
                     if (random.nextInt(10) < 10 - ammoReinforced) ((IAmmo) ammo.getItem()).consumeAmmo(1, ammo);
                 } else player.inventory.consumeInventoryItem(ammo.getItem());
+            } else {
+                // for non-custom IAmmo types (like vanilla arrows), simply consume them like in vanilla
+                player.inventory.consumeInventoryItem(ammo.getItem());
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21149

Vanilla arrows are compatible and found by short and longbows code, but the code does not handle consuming them since vanilla arrows do not implement the custom IAmmo. This allowed for infinite ammo using one vanilla arrow, and duplicating them by picking them up.