### PR TITLE
Add additional drawing method for inventory tabs

### DIFF
--- a/src/main/java/tconstruct/client/tabs/AbstractTab.java
+++ b/src/main/java/tconstruct/client/tabs/AbstractTab.java
@@ -23,6 +23,18 @@ public abstract class AbstractTab extends GuiButton {
 
     @Override
     public void drawButton(Minecraft mc, int mouseX, int mouseY) {
+        drawButton(mc, this.renderStack, false);
+    }
+
+    /**
+     * Draws inventory tab
+     * 
+     * @param mc
+     * @param tabIcon                 Item to use as tab icon
+     * @param enableItemIconDepthTest whether to enable GL_DEPTH_TEST for rendering the item icon
+     */
+
+    protected void drawButton(Minecraft mc, ItemStack tabIcon, boolean enableItemIconDepthTest) {
         if (this.visible) {
             GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
@@ -39,18 +51,16 @@ public abstract class AbstractTab extends GuiButton {
             this.itemRenderer.zLevel = 100.0F;
             GL11.glEnable(GL11.GL_LIGHTING);
             GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+            if (enableItemIconDepthTest) GL11.glEnable(GL11.GL_DEPTH_TEST);
             this.itemRenderer.renderItemAndEffectIntoGUI(
                     mc.fontRenderer,
                     mc.renderEngine,
-                    renderStack,
+                    tabIcon,
                     xPosition + 6,
                     yPosition + 8);
-            this.itemRenderer.renderItemOverlayIntoGUI(
-                    mc.fontRenderer,
-                    mc.renderEngine,
-                    renderStack,
-                    xPosition + 6,
-                    yPosition + 8);
+            this.itemRenderer
+                    .renderItemOverlayIntoGUI(mc.fontRenderer, mc.renderEngine, tabIcon, xPosition + 6, yPosition + 8);
+            if (enableItemIconDepthTest) GL11.glDisable(GL11.GL_DEPTH_TEST);
             GL11.glDisable(GL11.GL_LIGHTING);
             GL11.glEnable(GL11.GL_BLEND);
             this.itemRenderer.zLevel = 0.0F;


### PR DESCRIPTION
AdventureBackpack was using a copy of the inventory tab drawing method with some slight modifications. This meant that the changes in #211 didn't apply to the Adventure Backpack. This PR adds the necessary functionality to TiCon itself so that we can drop the duplicated code in AdventureBackpack.

addresses https://github.com/GTNewHorizons/TinkersConstruct/pull/211#issuecomment-3369351588