### PR TITLE
Fix shurikens, throwing knives, and javelins fitting in the quiver bauble slot

### DIFF
--- a/src/main/java/tconstruct/library/weaponry/AmmoItem.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoItem.java
@@ -1,24 +1,14 @@
 package tconstruct.library.weaponry;
 
-import java.util.List;
-
-import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.StatCollector;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
-import baubles.api.BaubleType;
-import baubles.api.IBauble;
-import baubles.api.expanded.BaubleExpandedSlots;
-import baubles.api.expanded.IBaubleExpanded;
 import baubles.common.lib.PlayerHandler;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import mods.battlegear2.api.PlayerEventChild;
 import mods.battlegear2.api.weapons.IBattlegearWeapon;
 import tconstruct.compat.LoadedMods;
@@ -26,11 +16,8 @@ import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.tools.TinkerTools;
 
-@Optional.InterfaceList({
-        @Optional.Interface(modid = "battlegear2", iface = "mods.battlegear2.api.weapons.IBattlegearWeapon"),
-        @Optional.Interface(modid = "Baubles|Expanded", iface = "baubles.api.expanded.IBaubleExpanded"),
-        @Optional.Interface(modid = "Baubles", iface = "baubles.api.IBauble") })
-public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IAmmo, IBauble, IBaubleExpanded {
+@Optional.Interface(modid = "battlegear2", iface = "mods.battlegear2.api.weapons.IBattlegearWeapon")
+public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IAmmo {
 
     public AmmoItem(int baseDamage, String name) {
         super(baseDamage);
@@ -220,65 +207,4 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
                 && (offhand.getItem() != TinkerTools.cleaver && offhand.getItem() != TinkerTools.battleaxe);
     }
 
-    @Override
-    @Optional.Method(modid = "Baubles|Expanded")
-    public String[] getBaubleTypes(ItemStack itemstack) {
-        return new String[] { BaubleExpandedSlots.quiverType };
-    }
-
-    // Fallback for base Baubles
-    @Override
-    @Optional.Method(modid = "Baubles")
-    public BaubleType getBaubleType(ItemStack itemStack) {
-        return BaubleType.RING;
-    }
-
-    @Override
-    @Optional.Method(modid = "Baubles")
-    public void onWornTick(ItemStack itemstack, EntityLivingBase player) {
-        onUpdate(itemstack, player.worldObj, player, 0, false);
-    }
-
-    @Override
-    @Optional.Method(modid = "Baubles")
-    public void onEquipped(ItemStack itemstack, EntityLivingBase player) {}
-
-    @Override
-    @Optional.Method(modid = "Baubles")
-    public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
-
-    @Override
-    @Optional.Method(modid = "Baubles")
-    public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
-        return true;
-    }
-
-    @Override
-    @Optional.Method(modid = "Baubles")
-    public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
-        return true;
-    }
-
-    @Override
-    @SideOnly(Side.CLIENT)
-    public void addInformation(ItemStack stack, EntityPlayer player, List<String> lines, boolean advanced) {
-        super.addInformation(stack, player, lines, advanced);
-        if (LoadedMods.baubles) addBaubleInformation(lines);
-    }
-
-    @SideOnly(Side.CLIENT)
-    @Optional.Method(modid = "Baubles")
-    private void addBaubleInformation(List<String> lines) {
-        if (LoadedMods.baublesExpanded) {
-            if (GuiScreen.isShiftKeyDown()) {
-                lines.add(StatCollector.translateToLocal("tooltip.compatibleslots"));
-                lines.add(StatCollector.translateToLocal("slot.quiver"));
-                if (LoadedMods.tiCTooltips) lines.add(""); // Required for spacing
-            } else if (!LoadedMods.tiCTooltips) {
-                lines.add(StatCollector.translateToLocal("tooltip.shiftprompt"));
-            }
-        } else {
-            lines.add(StatCollector.translateToLocal("baubletype.any"));
-        }
-    }
 }

--- a/src/main/java/tconstruct/weaponry/ammo/ArrowAmmo.java
+++ b/src/main/java/tconstruct/weaponry/ammo/ArrowAmmo.java
@@ -2,13 +2,24 @@ package tconstruct.weaponry.ammo;
 
 import java.util.List;
 
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
+import baubles.api.expanded.BaubleExpandedSlots;
+import baubles.api.expanded.IBaubleExpanded;
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import tconstruct.TConstruct;
+import tconstruct.compat.LoadedMods;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.tools.CustomMaterial;
@@ -18,7 +29,10 @@ import tconstruct.library.weaponry.AmmoItem;
 import tconstruct.tools.TinkerTools;
 import tconstruct.weaponry.TinkerWeaponry;
 
-public class ArrowAmmo extends AmmoItem {
+@Optional.InterfaceList({
+        @Optional.Interface(modid = "Baubles|Expanded", iface = "baubles.api.expanded.IBaubleExpanded"),
+        @Optional.Interface(modid = "Baubles", iface = "baubles.api.IBauble") })
+public class ArrowAmmo extends AmmoItem implements IBauble, IBaubleExpanded {
 
     public static ItemStack vanillaArrow;
 
@@ -134,5 +148,67 @@ public class ArrowAmmo extends AmmoItem {
             return EnumChatFormatting.GOLD + StatCollector.translateToLocal("modifier.tool.blaze");
         if (part > 1) return ""; // only head has ability otherwise
         return super.getAbilityNameForType(type, part);
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles|Expanded")
+    public String[] getBaubleTypes(ItemStack itemstack) {
+        return new String[] { BaubleExpandedSlots.quiverType };
+    }
+
+    // Fallback for base Baubles
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public BaubleType getBaubleType(ItemStack itemStack) {
+        return BaubleType.RING;
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public void onWornTick(ItemStack itemstack, EntityLivingBase player) {
+        onUpdate(itemstack, player.worldObj, player, 0, false);
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public void onEquipped(ItemStack itemstack, EntityLivingBase player) {}
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
+        return true;
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
+        return true;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack stack, EntityPlayer player, List<String> lines, boolean advanced) {
+        super.addInformation(stack, player, lines, advanced);
+        if (LoadedMods.baubles) addBaubleInformation(lines);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Optional.Method(modid = "Baubles")
+    public static void addBaubleInformation(List<String> lines) {
+        if (LoadedMods.baublesExpanded) {
+            if (GuiScreen.isShiftKeyDown()) {
+                lines.add(StatCollector.translateToLocal("tooltip.compatibleslots"));
+                lines.add(StatCollector.translateToLocal("slot.quiver"));
+                if (LoadedMods.tiCTooltips) lines.add(""); // Required for spacing
+            } else if (!LoadedMods.tiCTooltips) {
+                lines.add(StatCollector.translateToLocal("tooltip.shiftprompt"));
+            }
+        } else {
+            lines.add(StatCollector.translateToLocal("baubletype.any"));
+        }
     }
 }

--- a/src/main/java/tconstruct/weaponry/ammo/BoltAmmo.java
+++ b/src/main/java/tconstruct/weaponry/ammo/BoltAmmo.java
@@ -2,9 +2,19 @@ package tconstruct.weaponry.ammo;
 
 import java.util.List;
 
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
+import baubles.api.expanded.BaubleExpandedSlots;
+import baubles.api.expanded.IBaubleExpanded;
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import tconstruct.compat.LoadedMods;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.tools.CustomMaterial;
@@ -15,7 +25,10 @@ import tconstruct.library.weaponry.AmmoItem;
 import tconstruct.tools.TinkerTools;
 import tconstruct.weaponry.TinkerWeaponry;
 
-public class BoltAmmo extends AmmoItem {
+@Optional.InterfaceList({
+        @Optional.Interface(modid = "Baubles|Expanded", iface = "baubles.api.expanded.IBaubleExpanded"),
+        @Optional.Interface(modid = "Baubles", iface = "baubles.api.IBauble") })
+public class BoltAmmo extends AmmoItem implements IBauble, IBaubleExpanded {
 
     public BoltAmmo() {
         super(0, "Bolts");
@@ -108,4 +121,51 @@ public class BoltAmmo extends AmmoItem {
             return "";
         return super.getAbilityNameForType(type, part);
     }
+
+    @Override
+    @Optional.Method(modid = "Baubles|Expanded")
+    public String[] getBaubleTypes(ItemStack itemstack) {
+        return new String[] { BaubleExpandedSlots.quiverType };
+    }
+
+    // Fallback for base Baubles
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public BaubleType getBaubleType(ItemStack itemStack) {
+        return BaubleType.RING;
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public void onWornTick(ItemStack itemstack, EntityLivingBase player) {
+        onUpdate(itemstack, player.worldObj, player, 0, false);
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public void onEquipped(ItemStack itemstack, EntityLivingBase player) {}
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
+        return true;
+    }
+
+    @Override
+    @Optional.Method(modid = "Baubles")
+    public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
+        return true;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack stack, EntityPlayer player, List<String> lines, boolean advanced) {
+        super.addInformation(stack, player, lines, advanced);
+        if (LoadedMods.baubles) ArrowAmmo.addBaubleInformation(lines);
+    }
+
 }


### PR DESCRIPTION
Them fitting there was unintended and they could not be used from the slot anyway.