### PR TITLE
Fix: Prevent broken tools from being able to create EFR stripped logs or dirt paths

### DIFF
--- a/src/main/java/tconstruct/library/tools/HarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/HarvestTool.java
@@ -99,6 +99,11 @@ public abstract class HarvestTool extends ToolCore {
         Set<String> set = new HashSet<>();
 
         if (stack != null && stack.getItem() instanceof HarvestTool) {
+
+            // Broken tools are not considered as valid for tool classes
+            NBTTagCompound tags = stack.getTagCompound().getCompoundTag("InfiTool");
+            if (tags.getBoolean("Broken")) return set;
+
             set.add(((HarvestTool) stack.getItem()).getHarvestType());
         }
 

--- a/src/main/java/tconstruct/library/tools/HarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/HarvestTool.java
@@ -98,11 +98,11 @@ public abstract class HarvestTool extends ToolCore {
     public Set<String> getToolClasses(ItemStack stack) {
         Set<String> set = new HashSet<>();
 
-        if (stack != null && stack.getItem() instanceof HarvestTool) {
+        if (stack != null && stack.hasTagCompound() && stack.getItem() instanceof HarvestTool) {
 
             // Broken tools are not considered as valid for tool classes
             NBTTagCompound tags = stack.getTagCompound().getCompoundTag("InfiTool");
-            if (tags.getBoolean("Broken")) return set;
+            if (tags == null || tags.getBoolean("Broken")) return set;
 
             set.add(((HarvestTool) stack.getItem()).getHarvestType());
         }


### PR DESCRIPTION
This PR makes so that broken TiC tools do not expose any tool classes. This in turn prevents EFR from recognizing the tool as valid for dirt paths and log stripping.