### PR TITLE
Fix tough rod and full guard clay casts

### DIFF
--- a/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
@@ -1156,7 +1156,7 @@ public class TinkerSmeltery {
                             / 2;
                     ItemStack metalCast = new ItemStack(TinkerTools.patternOutputs[iter], 1, liquidDamage[iterTwo]);
                     tableCasting.addCastingRecipe(metalCast, new FluidStack(fs, fluidAmount), cast, 50);
-                    if (isValidClayCast(iter)) {
+                    if (isValidClayCast(iter + 1)) {
                         tableCasting.addCastingRecipe(metalCast, new FluidStack(fs, fluidAmount), clay_cast, true, 50);
                     }
                     Smeltery.addMelting(FluidType.getFluidType(fs), metalCast, 0, fluidAmount);


### PR DESCRIPTION
iter+1 is used to calculate the meta earlier in this loop so the validity checks are all off by one. 

This was causing a bugged texture and nameless tough rod clay cast (not supposed to exist at all) to generate in recipes, and was also causing no recipes to generate for full guard clay cast.

Fixes https://github.com/GTNewHorizons/TinkersConstruct/issues/201