### PR TITLE
Add support for translucent tools and parts

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,8 @@ dependencies {
     compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta62:api')
     api("com.github.GTNewHorizons:Mantle:0.5.1:dev")
     api("com.github.GTNewHorizons:ForgeMultipart:1.6.8:dev")
+    // gtnhlib is compileOnlyApi by us, but needed at runtime by nei, so require the correct version
+    api("com.github.GTNewHorizons:GTNHLib:0.8.17:dev")
     implementation("com.github.GTNewHorizons:NotEnoughItems:2.8.14-GTNH:dev")
     compileOnlyApi("curse.maven:cofh-core-69162:2388751")
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:api")
@@ -18,8 +20,6 @@ dependencies {
     compileOnlyApi("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     compileOnlyApi("com.github.GTNewHorizons:Natura:2.8.9:dev")
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.0-GTNH:dev')
-
-    compileOnlyApi("com.github.GTNewHorizons:GTNHLib:0.8.17:dev")
 
     // For testing scythe crop harvesting
     // devOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,6 +19,8 @@ dependencies {
     compileOnlyApi("com.github.GTNewHorizons:Natura:2.8.9:dev")
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.0-GTNH:dev')
 
+    compileOnlyApi("com.github.GTNewHorizons:GTNHLib:0.8.15:dev")
+
     // For testing scythe crop harvesting
     // devOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     // devOnlyNonPublishable("com.github.GTNewHorizons:harvestcraft:1.3.2-GTNH:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnlyApi("com.github.GTNewHorizons:Natura:2.8.9:dev")
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.0-GTNH:dev')
 
-    compileOnlyApi("com.github.GTNewHorizons:GTNHLib:0.8.15:dev")
+    compileOnlyApi("com.github.GTNewHorizons:GTNHLib:0.8.17:dev")
 
     // For testing scythe crop harvesting
     // devOnlyNonPublishable("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")

--- a/src/main/java/tconstruct/client/FlexibleToolRenderer.java
+++ b/src/main/java/tconstruct/client/FlexibleToolRenderer.java
@@ -94,6 +94,7 @@ public class FlexibleToolRenderer implements IItemRenderer {
         }
 
         GL11.glPushMatrix();
+        GL11.glEnable(GL11.GL_BLEND);
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 
         if (type != ItemRenderType.ENTITY) {
@@ -205,6 +206,7 @@ public class FlexibleToolRenderer implements IItemRenderer {
 
         tess.draw();
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }
 
@@ -214,8 +216,8 @@ public class FlexibleToolRenderer implements IItemRenderer {
 
         GL11.glDisable(GL11.GL_LIGHTING);
         GL11.glEnable(GL11.GL_ALPHA_TEST);
-        GL11.glAlphaFunc(GL11.GL_GREATER, 0.5F);
-        // GL11.glDisable(GL11.GL_BLEND);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.4F);
+        GL11.glEnable(GL11.GL_BLEND);
 
         tess.startDrawingQuads();
 
@@ -235,7 +237,7 @@ public class FlexibleToolRenderer implements IItemRenderer {
         }
         tess.draw();
 
-        // GL11.glEnable(GL11.GL_BLEND);
+        GL11.glDisable(GL11.GL_BLEND);
         GL11.glDisable(GL11.GL_ALPHA_TEST);
         GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
         GL11.glEnable(GL11.GL_LIGHTING);

--- a/src/main/java/tconstruct/library/tools/DynamicToolPart.java
+++ b/src/main/java/tconstruct/library/tools/DynamicToolPart.java
@@ -11,6 +11,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 
+import com.gtnewhorizon.gtnhlib.api.ITranslucentItem;
+
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import mantle.items.abstracts.CraftingItem;
@@ -19,7 +22,8 @@ import tconstruct.library.util.IToolPart;
 import tconstruct.library.util.TextureHelper;
 import tconstruct.util.config.PHConstruct;
 
-public class DynamicToolPart extends CraftingItem implements IToolPart {
+@Optional.Interface(modid = "gtnhlib", iface = "com.gtnewhorizon.gtnhlib.api.ITranslucentItem")
+public class DynamicToolPart extends CraftingItem implements IToolPart, ITranslucentItem {
 
     public String partName;
     public String texture;

--- a/src/main/java/tconstruct/tools/items/ToolPart.java
+++ b/src/main/java/tconstruct/tools/items/ToolPart.java
@@ -7,13 +7,17 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
+import com.gtnewhorizon.gtnhlib.api.ITranslucentItem;
+
+import cpw.mods.fml.common.Optional;
 import mantle.items.abstracts.CraftingItem;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.util.IToolPart;
 import tconstruct.tools.TinkerTools;
 
+@Optional.Interface(modid = "gtnhlib", iface = "com.gtnewhorizon.gtnhlib.api.ITranslucentItem")
 @Deprecated
-public class ToolPart extends CraftingItem implements IToolPart {
+public class ToolPart extends CraftingItem implements IToolPart, ITranslucentItem {
 
     public String partName;
 


### PR DESCRIPTION
Depends on https://github.com/GTNewHorizons/GTNHLib/pull/215

For utilities in excess inverted ingot tools

There are some items that I didn't add here because they explicitly disable blending and I'm not familiar enough with the tinekr's codebase to know if I can remove that, so those still won't support transparency 