### PR TITLE
avoid creation of empty NBT tags in WeaponryHandler#boneanaBuilding

### DIFF
--- a/src/main/java/tconstruct/weaponry/WeaponryHandler.java
+++ b/src/main/java/tconstruct/weaponry/WeaponryHandler.java
@@ -378,13 +378,15 @@ public class WeaponryHandler {
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void boneanaBuilding(ToolCraftEvent.NormalTool event) {
         // is it a boneana?
-        if ("\u00A7f\u2400Bonæna".equals(event.toolTag.getCompoundTag("display").getString("Name"))) {
+        if (!event.toolTag.hasKey("display")) return;
+        final NBTTagCompound display = event.toolTag.getCompoundTag("display");
+        if ("\u00A7f\u2400Bonæna".equals(display.getString("Name"))) {
             // set correct name
-            event.toolTag.getCompoundTag("display").setString("Name", EnumChatFormatting.YELLOW + "Bonæna");
+            display.setString("Name", EnumChatFormatting.YELLOW + "Bonæna");
             // lore!
             NBTTagList lore = new NBTTagList();
             lore.appendTag(new NBTTagString(StatCollector.translateToLocal("tool.boneana.lore")));
-            event.toolTag.getCompoundTag("display").setTag("Lore", lore);
+            display.setTag("Lore", lore);
 
             // let's polish it up a bit!
             NBTTagCompound tag = event.toolTag.getCompoundTag("InfiTool");


### PR DESCRIPTION
by checking if `hasKey` returns true because calling the `getCompoundTag` directly will return a new NBTTag if the key is not present