### PR TITLE
Clean up Tool Station GUI code

### DIFF
--- a/src/main/java/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/tconstruct/library/tools/ToolCore.java
@@ -111,8 +111,12 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
         return this.getClass().getSimpleName();
     }
 
+    public String getUnlocalizedToolName() {
+        return "tool." + this.getToolName().toLowerCase();
+    }
+
     public String getLocalizedToolName() {
-        return StatCollector.translateToLocal("tool." + getToolName().toLowerCase());
+        return StatCollector.translateToLocal(this.getUnlocalizedToolName());
     }
 
     /* Rendering */
@@ -334,7 +338,7 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
         list.add("");
         int attack = (int) (tags.getCompoundTag("InfiTool").getInteger("Attack") * this.getDamageModifier());
         list.add(
-                EnumChatFormatting.BLUE.toString() + "+"
+                EnumChatFormatting.BLUE + "+"
                         + attack
                         + " "
                         + StatCollector.translateToLocalFormatted("attribute.name.generic.attackDamage"));

--- a/src/main/java/tconstruct/tools/ToolProxyClient.java
+++ b/src/main/java/tconstruct/tools/ToolProxyClient.java
@@ -23,7 +23,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.client.event.sound.SoundLoadEvent;
@@ -762,7 +761,7 @@ public class ToolProxyClient extends ToolProxyCommon {
                 0,
                 new int[] { 0, 1, 2, 13 },
                 new int[] { 13, 13, 13, 13 },
-                StatCollector.translateToLocal("gui.toolforge1"),
+                "gui.toolforge1",
                 "gui.toolforge2");
 
         // tier 1 tools
@@ -774,7 +773,7 @@ public class ToolProxyClient extends ToolProxyCommon {
                     itemIconsT1[i][2],
                     iconCoordsT1[i * 2],
                     iconCoordsT1[i * 2 + 1],
-                    tier1Tools[i].getLocalizedToolName(),
+                    tier1Tools[i].getUnlocalizedToolName(),
                     locString);
         }
 
@@ -787,7 +786,7 @@ public class ToolProxyClient extends ToolProxyCommon {
                     itemIconsT2[i][2],
                     iconCoordsT2[i * 2],
                     iconCoordsT2[i * 2 + 1],
-                    tier2Tools[i].getLocalizedToolName(),
+                    tier2Tools[i].getUnlocalizedToolName(),
                     locString);
         }
     }

--- a/src/main/java/tconstruct/tools/gui/ToolForgeGui.java
+++ b/src/main/java/tconstruct/tools/gui/ToolForgeGui.java
@@ -1,8 +1,6 @@
 package tconstruct.tools.gui;
 
-import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.relauncher.Side;
@@ -13,8 +11,6 @@ import tconstruct.tools.logic.ToolForgeLogic;
 
 @SideOnly(Side.CLIENT)
 public class ToolForgeGui extends ToolStationGui {
-
-    int selectedButton;
 
     public ToolForgeGui(InventoryPlayer inventoryplayer, ToolForgeLogic stationlogic, World world, int x, int y,
             int z) {
@@ -70,40 +66,13 @@ public class ToolForgeGui extends ToolStationGui {
     }
 
     @Override
-    protected void actionPerformed(GuiButton button) {
-        GuiButtonTool b = (GuiButtonTool) button;
-        ((GuiButton) this.buttonList.get(selectedButton)).enabled = true;
-        selectedButton = button.id;
-        button.enabled = false;
-
-        setSlotType(b.element.slotType);
-        iconX = b.element.iconsX;
-        iconY = b.element.iconsY;
-        title = "\u00A7n" + b.element.title;
-        body = StatCollector.translateToLocal(b.element.body);
-        if (body != null) {
-            int i;
-            // for some really weird reason replaceAll doesn't find "\\n", but indexOf does. We have to replace
-            // manually.
-            while ((i = body.indexOf("\\n")) >= 0) {
-                body = body.substring(0, i) + '\n' + body.substring(i + 2);
-            }
-        }
-    }
-
-    @Override
-    void resetGui() {
-        this.text.setText("");
-        selectedButton = 0;
-        setSlotType(0);
+    protected void setIconUVs() {
         iconX = new int[] { 0, 1, 2, 13 };
         iconY = new int[] { 13, 13, 13, 13 };
-        title = "\u00A7n" + StatCollector.translateToLocal("gui.toolforge1");
-        body = StatCollector.translateToLocal("gui.toolforge2");
     }
 
     @Override
-    void setSlotType(int type) {
+    protected void setSlotType(int type) {
         switch (type) {
             case 0:
                 slotX = new int[] { 56, 38, 38, 14 }; // Repair

--- a/src/main/java/tconstruct/tools/gui/ToolForgeGui.java
+++ b/src/main/java/tconstruct/tools/gui/ToolForgeGui.java
@@ -18,10 +18,7 @@ public class ToolForgeGui extends ToolStationGui {
     }
 
     @Override
-    public void initGui() {
-        super.initGui();
-
-        this.buttonList.clear();
+    protected void createToolButtons() {
         ToolGuiElement repair = TConstructClientRegistry.toolButtons.get(0);
         GuiButtonTool repairButton = new GuiButtonTool(
                 0,

--- a/src/main/java/tconstruct/tools/gui/ToolStationGui.java
+++ b/src/main/java/tconstruct/tools/gui/ToolStationGui.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
@@ -47,7 +48,7 @@ public class ToolStationGui extends GuiContainer implements INEIGuiHandler {
         selectedButton = 0;
         setSlotType(0);
         setIconUVs();
-        title = "§n" + StatCollector.translateToLocal("gui.toolforge1");
+        title = EnumChatFormatting.UNDERLINE + StatCollector.translateToLocal("gui.toolforge1");
         body = StatCollector.translateToLocal("gui.toolforge2");
         Keyboard.enableRepeatEvents(true);
     }
@@ -80,20 +81,11 @@ public class ToolStationGui extends GuiContainer implements INEIGuiHandler {
         }
 
         this.buttonList.clear();
-        ToolGuiElement repair = TConstructClientRegistry.toolButtons.get(0);
-        GuiButtonTool repairButton = new GuiButtonTool(
-                0,
-                this.guiLeft,
-                this.guiTop,
-                repair.buttonIconX,
-                repair.buttonIconY,
-                repair.domain,
-                repair.texture,
-                repair); // Repair
-        repairButton.enabled = false;
-        this.buttonList.add(repairButton);
+        createToolButtons();
+    }
 
-        for (int iter = 1; iter < TConstructClientRegistry.toolButtons.size(); iter++) {
+    protected void createToolButtons() {
+        for (int iter = 0; iter < TConstructClientRegistry.toolButtons.size(); iter++) {
             ToolGuiElement element = TConstructClientRegistry.toolButtons.get(iter);
             GuiButtonTool button = new GuiButtonTool(
                     iter,
@@ -106,6 +98,7 @@ public class ToolStationGui extends GuiContainer implements INEIGuiHandler {
                     element);
             this.buttonList.add(button);
         }
+        this.buttonList.get(0).enabled = false;
     }
 
     @Override
@@ -226,7 +219,7 @@ public class ToolStationGui extends GuiContainer implements INEIGuiHandler {
             Keyboard.enableRepeatEvents(false);
             this.mc.thePlayer.closeScreen();
         } else if (text.textboxKeyTyped(typedChar, keyCode)) {
-            final var toolName = text.getText().trim();
+            final String toolName = text.getText().trim();
             logic.setToolname(toolName);
             updateServer(toolName);
         }

--- a/src/main/java/tconstruct/tools/items/CreativeModifier.java
+++ b/src/main/java/tconstruct/tools/items/CreativeModifier.java
@@ -24,41 +24,41 @@ public class CreativeModifier extends Item {
         this.setCreativeTab(TConstructRegistry.materialTab);
     }
 
-    @SideOnly(Side.CLIENT)
     /**
      * returns a list of items with the same ID, but different meta (eg: dye returns 16 items)
      */
     @Override
-    public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List<ItemStack> par3List) {
-        par3List.add(new ItemStack(par1, 1, 0));
+    @SideOnly(Side.CLIENT)
+    public void getSubItems(Item item1, CreativeTabs creativeTabs, List<ItemStack> list) {
+        list.add(new ItemStack(item1, 1, 0));
 
         for (ToolRecipe recipe : ToolBuilder.instance.combos) {
             ToolCore tool = recipe.getType();
-            ItemStack item = new ItemStack(par1, 1, 0);
+            ItemStack item = new ItemStack(item1, 1, 0);
             NBTTagCompound compound = new NBTTagCompound();
             compound.setString("TargetLock", tool.getToolName());
 
             item.setTagCompound(compound);
-            par3List.add(item);
+            list.add(item);
         }
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister iconRegister) {
         this.itemIcon = iconRegister.registerIcon("tinker:skull_char_gold");
     }
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean par4) {
+    public void addInformation(ItemStack stack, EntityPlayer player, List<String> list, boolean adv) {
         list.add(
                 StatCollector.translateToLocal("modifier.tooltip.Main") + " "
                         + StatCollector.translateToLocal("modifier.tooltip.Creative"));
         if (stack.hasTagCompound()) {
             String targetLock;
             targetLock = stack.getTagCompound().getString("TargetLock");
-            targetLock = StatCollector.translateToLocal("infitool." + targetLock.toLowerCase());
+            targetLock = StatCollector.translateToLocal("tool." + targetLock.toLowerCase());
             list.add(StatCollector.translateToLocal("creativeModLock.tooltip") + targetLock);
         }
     }

--- a/src/main/java/tconstruct/weaponry/items/Boneana.java
+++ b/src/main/java/tconstruct/weaponry/items/Boneana.java
@@ -38,12 +38,7 @@ public class Boneana extends Broadsword {
     }
 
     @Override
-    public String getLocalizedToolName() {
-        return "Bonæna";
-    }
-
-    @Override
-    public void getSubItems(Item id, CreativeTabs tab, List list) {
+    public void getSubItems(Item id, CreativeTabs tab, List<ItemStack> list) {
         // you are not welcome here >:C
     }
 }

--- a/src/main/resources/assets/tinker/lang/en_US.lang
+++ b/src/main/resources/assets/tinker/lang/en_US.lang
@@ -187,34 +187,6 @@ item.InfiTool.Shortbow.name=Shortbow
 item.InfiTool.Arrow.name=Arrow
 item.InfiTool.Mattock.name=Mattock
 
-infitool.pickaxe=Pickaxe
-infitool.shovel=Shovel
-infitool.hatchet=Hatchet
-infitool.broadsword=Broadsword
-infitool.longsword=Longsword
-infitool.rapier=Rapier
-infitool.fryingpan=Frying Pan
-infitool.battlesign=Battlesign
-infitool.dagger=Dagger
-infitool.chisel=Chisel
-infitool.scythe=Scythe
-infitool.lumberaxe=Lumber Axe
-infitool.cleaver=Cleaver
-infitool.excavator=Excavator
-infitool.hammer=Hammer
-infitool.battleaxe=Battleaxe
-infitool.cutlass=Cutlass
-infitool.arrow=Arrow
-infitool.mattock=Mattock
-infitool.shortbow=Shortbow
-infitool.longbow=Longbow
-infitool.crossbow=Crossbow
-infitool.arrowammo=Arrows
-infitool.boltammo=Bolts
-infitool.shuriken=Shuriken
-infitool.throwingknife=Throwing Knife
-infitool.javelin=Javelin
-
 item.tconstruct.PotionLauncher.name=Potion Launcher
 
 item.tool.randomarrow=Random Streamer
@@ -1049,6 +1021,7 @@ tool.boltammo=Bolts
 tool.shuriken=Shuriken
 tool.throwingknife=Throwing Knife
 tool.javelin=Javelin
+tool.boneana=Bonæna
 
 # Customization of default tool names based on tool and material
 #tool.shovel.wood=Wooden Shovel


### PR DESCRIPTION
Fixes the renaming text box being unusable.

Changes:
- De-duplicated fields & code.
- Made the title text of the tool property descriptions switch languages properly
- Removed duplicate lang keys
- Made the Tool Station GUI use the `GuiTextField` properly
- Minor fixes related to generic injection