### PR TITLE
Fixes Inventory Tab Pixels

### DIFF
--- a/src/main/java/tconstruct/client/tabs/AbstractTab.java
+++ b/src/main/java/tconstruct/client/tabs/AbstractTab.java
@@ -45,6 +45,9 @@ public abstract class AbstractTab extends GuiButton {
 
             mc.renderEngine.bindTexture(this.texture);
             this.drawTexturedModalRect(this.xPosition, yPos, xOffset * 28, yTexPos, 28, ySize);
+            if (this.enabled) {
+                this.drawUnselectedTabDecorations(mc, xOffset, yTexPos, yPos, ySize);
+            }
 
             RenderHelper.enableGUIStandardItemLighting();
             this.zLevel = 100.0F;
@@ -68,6 +71,9 @@ public abstract class AbstractTab extends GuiButton {
             RenderHelper.disableStandardItemLighting();
         }
     }
+
+    protected void drawUnselectedTabDecorations(Minecraft mc, int textureXOffset, int textureYStart, int tabTopY,
+            int tabHeight) {}
 
     @Override
     public boolean mousePressed(Minecraft mc, int mouseX, int mouseY) {

--- a/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
+++ b/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
@@ -1,5 +1,6 @@
 package tconstruct.client.tabs;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
@@ -17,5 +18,19 @@ public class InventoryTabVanilla extends AbstractTab {
     @Override
     public boolean shouldAddToList() {
         return true;
+    }
+
+    @Override
+    protected void drawUnselectedTabDecorations(Minecraft mc, int textureXOffset, int textureYStart, int tabTopY,
+            int tabHeight) {
+        int textureX = textureXOffset * 28;
+        int sourceY = 29;
+        int targetY = tabTopY + tabHeight;
+
+        // Extend the bottom-left corner on the unselected vanilla tab.
+        // 0,29 -> two extra pixels down; 1,29 -> one extra pixel down.
+        this.drawTexturedModalRect(this.xPosition, targetY, textureX, sourceY, 1, 1);
+        this.drawTexturedModalRect(this.xPosition, targetY + 1, textureX, sourceY, 1, 1);
+        this.drawTexturedModalRect(this.xPosition + 1, targetY, textureX + 1, sourceY, 1, 1);
     }
 }


### PR DESCRIPTION
Fixes game breaking bug, where 3 pixels where not shown on first inactive "creative like" tab. Literally unplayable before.


| Before | After |
| - | - |
| <img width="202" height="113" alt="PRE" src="https://github.com/user-attachments/assets/d622c73b-b63f-4b7f-af86-98470258a94c" /> | <img width="198" height="119" alt="POST" src="https://github.com/user-attachments/assets/7704d873-3f31-4d86-969f-1a228f5598c6" /> |