### PR TITLE
Fix smeltery fuel gauge to account for all lava tanks

### DIFF
--- a/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
+++ b/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
@@ -343,7 +343,7 @@ public class SmelteryGui extends ActiveContainerGui {
     private List<String> getFuelTooltip() {
         ArrayList<String> list = new ArrayList<>();
         list.add("\u00A7f" + StatCollector.translateToLocal("gui.smeltery.fuel"));
-        list.add("mB: " + logic.fuelAmount + " / " + logic.fuelCapacity);
+        list.add(logic.fuelAmount + "/" + logic.fuelCapacity + " mB");
         return list;
     }
 

--- a/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
+++ b/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
@@ -44,17 +44,9 @@ public class SmelteryGui extends ActiveContainerGui {
         super((ActiveContainer) smeltery.getGuiContainer(inventoryplayer, world, x, y, z));
         logic = smeltery;
         smelterySize = smeltery.getBlockCapacity();
-        smeltery.updateFuelDisplay();
 
         columns = ((SmelteryContainer) this.inventorySlots).columns;
         xSize = 254 + (columns - 3) * 22; // Adjust for column count
-    }
-
-    @Override
-    public void initGui() {
-        super.initGui();
-
-        if (logic != null) logic.updateFuelDisplay();
     }
 
     @Override
@@ -66,11 +58,13 @@ public class SmelteryGui extends ActiveContainerGui {
             return;
         }
 
+        logic.updateFuelDisplay();
+        updateScrollbar(mouseX, mouseY);
+
         super.drawScreen(mouseX, mouseY, par3);
-        updateScrollbar(mouseX, mouseY, par3);
     }
 
-    protected void updateScrollbar(int mouseX, int mouseY, float par3) {
+    protected void updateScrollbar(int mouseX, int mouseY) {
         if (smelterySize > columns * maxRows) {
             boolean mouseDown = Mouse.isButtonDown(0);
             int lefto = this.guiLeft;
@@ -144,12 +138,11 @@ public class SmelteryGui extends ActiveContainerGui {
         }
 
         // lava/fuel
-        if (logic.fuelGague > 0) {
+        int fuel = logic.getScaledFuelGague(52);
+        if (fuel > 0) {
             int leftX = cornerX + 117;
-            int topY = (cornerY + 68) - logic.getScaledFuelGague(52);
-            int sizeX = 12;
-            int sizeY = logic.getScaledFuelGague(52);
-            if (mouseX >= leftX && mouseX <= leftX + sizeX && mouseY >= topY && mouseY < topY + sizeY) {
+            int topY = (cornerY + 68) - fuel;
+            if (mouseX >= leftX && mouseX <= leftX + 12 && mouseY >= topY && mouseY < topY + fuel) {
                 drawFluidStackTooltip(getFuelTooltip(logic.getFuel()), mouseX - cornerX + 36, mouseY - cornerY);
             }
         }
@@ -170,11 +163,11 @@ public class SmelteryGui extends ActiveContainerGui {
 
         // Fuel - Lava
         this.mc.getTextureManager().bindTexture(TextureMap.locationBlocksTexture);
-        if (logic.fuelGague > 0) {
+        int fuel = logic.getScaledFuelGague(52);
+        if (fuel > 0) {
             FluidStack fuelStack = logic.getFuel();
             IIcon lavaIcon = fuelStack.getFluid().getStillIcon();
             if (lavaIcon == null) lavaIcon = Blocks.lava.getIcon(0, 0);
-            int fuel = logic.getScaledFuelGague(52);
             int count = 0;
             while (fuel > 0) {
                 int size = Math.min(fuel, 16);
@@ -349,7 +342,7 @@ public class SmelteryGui extends ActiveContainerGui {
     private List<String> getFuelTooltip(FluidStack liquid) {
         ArrayList<String> list = new ArrayList<>();
         list.add("\u00A7f" + StatCollector.translateToLocal("gui.smeltery.fuel"));
-        list.add("mB: " + liquid.amount);
+        list.add("mB: " + liquid.amount + " / " + logic.fuelCapacity);
         return list;
     }
 

--- a/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
+++ b/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
@@ -39,6 +39,7 @@ public class SmelteryGui extends ActiveContainerGui {
     private final int columns;
     private final int smelterySize;
     public static final int maxRows = 8;
+    private int fuelDisplayTick = 0;
 
     public SmelteryGui(InventoryPlayer inventoryplayer, SmelteryLogic smeltery, World world, int x, int y, int z) {
         super((ActiveContainer) smeltery.getGuiContainer(inventoryplayer, world, x, y, z));
@@ -58,7 +59,7 @@ public class SmelteryGui extends ActiveContainerGui {
             return;
         }
 
-        logic.updateFuelDisplay();
+        if (fuelDisplayTick++ % 5 == 0) logic.updateFuelDisplay();
         updateScrollbar(mouseX, mouseY);
 
         super.drawScreen(mouseX, mouseY, par3);
@@ -143,7 +144,7 @@ public class SmelteryGui extends ActiveContainerGui {
             int leftX = cornerX + 117;
             int topY = (cornerY + 68) - fuel;
             if (mouseX >= leftX && mouseX <= leftX + 12 && mouseY >= topY && mouseY < topY + fuel) {
-                drawFluidStackTooltip(getFuelTooltip(logic.getFuel()), mouseX - cornerX + 36, mouseY - cornerY);
+                drawFluidStackTooltip(getFuelTooltip(), mouseX - cornerX + 36, mouseY - cornerY);
             }
         }
     }
@@ -339,10 +340,10 @@ public class SmelteryGui extends ActiveContainerGui {
         this.zLevel = 0;
     }
 
-    private List<String> getFuelTooltip(FluidStack liquid) {
+    private List<String> getFuelTooltip() {
         ArrayList<String> list = new ArrayList<>();
         list.add("\u00A7f" + StatCollector.translateToLocal("gui.smeltery.fuel"));
-        list.add("mB: " + liquid.amount + " / " + logic.fuelCapacity);
+        list.add("mB: " + logic.fuelAmount + " / " + logic.fuelCapacity);
         return list;
     }
 

--- a/src/main/java/tconstruct/smeltery/logic/LavaTankLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/LavaTankLogic.java
@@ -29,7 +29,7 @@ public class LavaTankLogic extends MultiServantLogic implements IFluidHandler {
     public int fill(ForgeDirection from, FluidStack resource, boolean doFill) {
         int amount = tank.fill(resource, doFill);
         if (amount > 0 && doFill) {
-            renderOffset += resource.amount;
+            renderOffset += amount;
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
             worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, this.getBlockType());
         }
@@ -41,7 +41,7 @@ public class LavaTankLogic extends MultiServantLogic implements IFluidHandler {
     public FluidStack drain(ForgeDirection from, int maxDrain, boolean doDrain) {
         FluidStack amount = tank.drain(maxDrain, doDrain);
         if (amount != null && doDrain) {
-            renderOffset = -maxDrain;
+            renderOffset = -amount.amount;
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
             worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, this.getBlockType());
         }

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -2,6 +2,7 @@ package tconstruct.smeltery.logic;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
@@ -78,7 +79,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     public int fuelCapacity;
     protected boolean inUse;
 
-    protected ArrayList<CoordTuple> lavaTanks;
+    protected List<CoordTuple> lavaTanks;
     protected ArrayList<CoordTuple> drains;
     protected CoordTuple activeLavaTank;
 
@@ -97,7 +98,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
     public SmelteryLogic() {
         super(0);
-        lavaTanks = new ArrayList<>();
+        lavaTanks = Collections.synchronizedList(new ArrayList<>());
         drains = new ArrayList<>();
         activeTemps = new int[0];
         meltingTemps = new int[0];
@@ -506,20 +507,33 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     public void updateFuelDisplay() {
         int totalAmount = 0;
         int totalCapacity = 0;
+        FluidStack fuelType = null;
 
-        for (CoordTuple coord : new ArrayList<>(lavaTanks)) {
-            if (!worldObj.blockExists(coord.x, coord.y, coord.z)) continue;
+        synchronized (lavaTanks) {
+            Iterator<CoordTuple> iter = lavaTanks.iterator();
+            while (iter.hasNext()) {
+                CoordTuple coord = iter.next();
+                if (!worldObj.blockExists(coord.x, coord.y, coord.z)) continue;
 
-            TileEntity te = worldObj.getTileEntity(coord.x, coord.y, coord.z);
-            if (!(te instanceof IFluidHandler)) continue;
+                TileEntity te = worldObj.getTileEntity(coord.x, coord.y, coord.z);
+                if (!(te instanceof IFluidHandler)) {
+                    iter.remove();
+                    continue;
+                }
 
-            FluidTankInfo[] info = ((IFluidHandler) te).getTankInfo(ForgeDirection.DOWN);
-            if (info.length <= 0) continue;
+                FluidTankInfo[] info = ((IFluidHandler) te).getTankInfo(ForgeDirection.DOWN);
+                if (info.length <= 0) continue;
 
-            totalCapacity += info[0].capacity;
+                totalCapacity += info[0].capacity;
 
-            if (info[0].fluid != null && info[0].fluid.amount > 0) {
-                totalAmount += info[0].fluid.amount;
+                if (info[0].fluid != null && info[0].fluid.amount > 0) {
+                    if (fuelType == null) {
+                        fuelType = info[0].fluid;
+                        totalAmount += info[0].fluid.amount;
+                    } else if (fuelType.isFluidEqual(info[0].fluid)) {
+                        totalAmount += info[0].fluid.amount;
+                    }
+                }
             }
         }
 
@@ -573,24 +587,26 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
         // our tank got derped or is empty. time to look for a new one!
         activeLavaTank = null;
-        for (CoordTuple tank : lavaTanks) {
-            // does the tank still exist?
-            if (!worldObj.blockExists(tank.x, tank.y, tank.z)) continue;
+        synchronized (lavaTanks) {
+            for (CoordTuple tank : lavaTanks) {
+                // does the tank still exist?
+                if (!worldObj.blockExists(tank.x, tank.y, tank.z)) continue;
 
-            // yes, it does, but is it a tank?
-            TileEntity tankContainer = worldObj.getTileEntity(tank.x, tank.y, tank.z);
-            if (!(tankContainer instanceof IFluidHandler)) continue;
+                // yes, it does, but is it a tank?
+                TileEntity tankContainer = worldObj.getTileEntity(tank.x, tank.y, tank.z);
+                if (!(tankContainer instanceof IFluidHandler)) continue;
 
-            // yes it is, but does it contain a liquid?
-            FluidTankInfo[] info = ((IFluidHandler) tankContainer).getTankInfo(ForgeDirection.DOWN);
-            if (info.length <= 0 || info[0].fluid == null || info[0].fluid.amount <= 0) continue;
+                // yes it is, but does it contain a liquid?
+                FluidTankInfo[] info = ((IFluidHandler) tankContainer).getTankInfo(ForgeDirection.DOWN);
+                if (info.length <= 0 || info[0].fluid == null || info[0].fluid.amount <= 0) continue;
 
-            // is it also a smeltery fuel?
-            if (!Smeltery.isSmelteryFuel(info[0].fluid.getFluid())) continue;
+                // is it also a smeltery fuel?
+                if (!Smeltery.isSmelteryFuel(info[0].fluid.getFluid())) continue;
 
-            // we found a tank! :)
-            activeLavaTank = tank;
-            return;
+                // we found a tank! :)
+                activeLavaTank = tank;
+                return;
+            }
         }
 
         // possibly assign default empty tank here (tanks.get(0)) so we don't have a null activeLavaTank if all are
@@ -601,19 +617,26 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     public FluidStack getFuel() {
         FluidStack combined = null;
 
-        for (CoordTuple coord : new ArrayList<>(lavaTanks)) {
-            if (!worldObj.blockExists(coord.x, coord.y, coord.z)) continue;
+        synchronized (lavaTanks) {
+            Iterator<CoordTuple> iter = lavaTanks.iterator();
+            while (iter.hasNext()) {
+                CoordTuple coord = iter.next();
+                if (!worldObj.blockExists(coord.x, coord.y, coord.z)) continue;
 
-            TileEntity te = worldObj.getTileEntity(coord.x, coord.y, coord.z);
-            if (!(te instanceof IFluidHandler)) continue;
+                TileEntity te = worldObj.getTileEntity(coord.x, coord.y, coord.z);
+                if (!(te instanceof IFluidHandler)) {
+                    iter.remove();
+                    continue;
+                }
 
-            FluidTankInfo[] info = ((IFluidHandler) te).getTankInfo(ForgeDirection.DOWN);
-            if (info.length <= 0 || info[0].fluid == null || info[0].fluid.amount <= 0) continue;
+                FluidTankInfo[] info = ((IFluidHandler) te).getTankInfo(ForgeDirection.DOWN);
+                if (info.length <= 0 || info[0].fluid == null || info[0].fluid.amount <= 0) continue;
 
-            if (combined == null) {
-                combined = info[0].fluid.copy();
-            } else if (combined.isFluidEqual(info[0].fluid)) {
-                combined.amount += info[0].fluid.amount;
+                if (combined == null) {
+                    combined = info[0].fluid.copy();
+                } else if (combined.isFluidEqual(info[0].fluid)) {
+                    combined.amount += info[0].fluid.amount;
+                }
             }
         }
 
@@ -756,17 +779,19 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
             if (tempValidStructure) {
                 // try to derive temperature from fueltank
                 activeLavaTank = null;
-                for (CoordTuple tank : lavaTanks) {
-                    TileEntity tankContainer = worldObj.getTileEntity(tank.x, tank.y, tank.z);
-                    if (!(tankContainer instanceof IFluidHandler)) continue;
+                synchronized (lavaTanks) {
+                    for (CoordTuple tank : lavaTanks) {
+                        TileEntity tankContainer = worldObj.getTileEntity(tank.x, tank.y, tank.z);
+                        if (!(tankContainer instanceof IFluidHandler)) continue;
 
-                    FluidStack liquid = ((IFluidHandler) tankContainer).getTankInfo(ForgeDirection.DOWN)[0].fluid;
-                    if (liquid == null) continue;
-                    if (!Smeltery.isSmelteryFuel(liquid.getFluid())) continue;
+                        FluidStack liquid = ((IFluidHandler) tankContainer).getTankInfo(ForgeDirection.DOWN)[0].fluid;
+                        if (liquid == null) continue;
+                        if (!Smeltery.isSmelteryFuel(liquid.getFluid())) continue;
 
-                    internalTemp = Smeltery.getFuelPower(liquid.getFluid());
-                    activeLavaTank = tank;
-                    break;
+                        internalTemp = Smeltery.getFuelPower(liquid.getFluid());
+                        activeLavaTank = tank;
+                        break;
+                    }
                 }
 
                 // no tank with fuel. we reserve the first found one

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -75,6 +75,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     public int useTime;
     public int fuelGague;
     public int fuelAmount;
+    public int fuelCapacity;
     protected boolean inUse;
 
     protected ArrayList<CoordTuple> lavaTanks;
@@ -262,8 +263,9 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     }
 
     public int getScaledFuelGague(int scale) {
-        int ret = (fuelGague * scale) / 52;
-        if (ret < 1) ret = 1;
+        if (fuelCapacity <= 0) return 0;
+        int ret = (int) ((float) fuelAmount * (float) scale / (float) fuelCapacity);
+        if (ret < 1 && fuelAmount > 0) ret = 1;
         return ret;
     }
 
@@ -502,22 +504,33 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     }
 
     public void updateFuelDisplay() {
-        // ensure our active tank is valid
-        verifyFuelTank();
-        if (activeLavaTank == null) {
-            fuelAmount = 0;
-            fuelGague = 0;
-            return;
+        int totalAmount = 0;
+        int totalCapacity = 0;
+
+        for (CoordTuple coord : lavaTanks) {
+            if (!worldObj.blockExists(coord.x, coord.y, coord.z)) continue;
+
+            TileEntity te = worldObj.getTileEntity(coord.x, coord.y, coord.z);
+            if (!(te instanceof IFluidHandler)) continue;
+
+            FluidTankInfo[] info = ((IFluidHandler) te).getTankInfo(ForgeDirection.DOWN);
+            if (info.length <= 0) continue;
+
+            totalCapacity += info[0].capacity;
+
+            if (info[0].fluid != null && info[0].fluid.amount > 0) {
+                totalAmount += info[0].fluid.amount;
+            }
         }
 
-        // checks are all done before in verifyFuelTank. Don't do this without checks!
-        IFluidHandler tankContainer = (IFluidHandler) worldObj
-                .getTileEntity(activeLavaTank.x, activeLavaTank.y, activeLavaTank.z);
-        FluidTankInfo[] info = tankContainer.getTankInfo(ForgeDirection.DOWN);
+        fuelAmount = totalAmount;
+        fuelCapacity = totalCapacity;
 
-        int capacity = info[0].capacity;
-        fuelAmount = info[0].fluid.amount;
-        fuelGague = (int) ((float) fuelAmount * 52f / (float) capacity);
+        if (totalCapacity > 0) {
+            fuelGague = (int) ((float) totalAmount * 52f / (float) totalCapacity);
+        } else {
+            fuelGague = 0;
+        }
     }
 
     // actually is updateFuel.
@@ -592,15 +605,28 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
     @SideOnly(Side.CLIENT)
     public FluidStack getFuel() {
-        if (activeLavaTank == null)
-            // sane default
+        FluidStack combined = null;
+
+        for (CoordTuple coord : lavaTanks) {
+            if (!worldObj.blockExists(coord.x, coord.y, coord.z)) continue;
+
+            TileEntity te = worldObj.getTileEntity(coord.x, coord.y, coord.z);
+            if (!(te instanceof IFluidHandler)) continue;
+
+            FluidTankInfo[] info = ((IFluidHandler) te).getTankInfo(ForgeDirection.DOWN);
+            if (info.length <= 0 || info[0].fluid == null || info[0].fluid.amount <= 0) continue;
+
+            if (combined == null) {
+                combined = info[0].fluid.copy();
+            } else if (combined.isFluidEqual(info[0].fluid)) {
+                combined.amount += info[0].fluid.amount;
+            }
+        }
+
+        if (combined == null) {
             return new FluidStack(FluidRegistry.LAVA, 0);
-
-        TileEntity tankContainer = worldObj.getTileEntity(activeLavaTank.x, activeLavaTank.y, activeLavaTank.z);
-        if (tankContainer instanceof IFluidHandler)
-            return ((IFluidHandler) tankContainer).getTankInfo(ForgeDirection.DOWN)[0].fluid;
-
-        return new FluidStack(FluidRegistry.LAVA, 0);
+        }
+        return combined;
     }
 
     public FluidStack getResultFor(ItemStack stack) {

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -507,7 +507,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
         int totalAmount = 0;
         int totalCapacity = 0;
 
-        for (CoordTuple coord : lavaTanks) {
+        for (CoordTuple coord : new ArrayList<>(lavaTanks)) {
             if (!worldObj.blockExists(coord.x, coord.y, coord.z)) continue;
 
             TileEntity te = worldObj.getTileEntity(coord.x, coord.y, coord.z);
@@ -525,12 +525,6 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
         fuelAmount = totalAmount;
         fuelCapacity = totalCapacity;
-
-        if (totalCapacity > 0) {
-            fuelGague = (int) ((float) totalAmount * 52f / (float) totalCapacity);
-        } else {
-            fuelGague = 0;
-        }
     }
 
     // actually is updateFuel.
@@ -607,7 +601,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     public FluidStack getFuel() {
         FluidStack combined = null;
 
-        for (CoordTuple coord : lavaTanks) {
+        for (CoordTuple coord : new ArrayList<>(lavaTanks)) {
             if (!worldObj.blockExists(coord.x, coord.y, coord.z)) continue;
 
             TileEntity te = worldObj.getTileEntity(coord.x, coord.y, coord.z);


### PR DESCRIPTION
## Summary

This PR fixes the smeltery fuel display on 1.7.10 so the controller GUI shows the total amount and total capacity of fuel across all connected lava tanks, instead of only the currently active tank.

## What changed

- Aggregate fuel amount across all connected lava tanks in `SmelteryLogic`
- Aggregate total fuel capacity across all connected lava tanks
- Scale the fuel bar using total fuel amount vs. total fuel capacity
- Update the fuel tooltip to display `current / total` fuel in mB
- Refresh the displayed fuel data during GUI rendering so the bar stays in sync while fuel is added or consumed
- Fix `LavaTankLogic` render offset updates to use the actual filled/drained amount instead of the requested amount
- Minor GUI cleanup:
  - remove duplicate fuel display updates
  - simplify fuel hover calculations
  - update scrollbar state before rendering

## Notes

This is a display/UI fix only.  
Actual fuel consumption behavior is unchanged and still uses the active fuel tank as before.

|Before|After|
|-|-|
|<img width="717" height="453" alt="image" src="https://github.com/user-attachments/assets/bcf166bb-afa1-47ec-bd58-3d8c3da5068d" />|<img width="623" height="399" alt="image" src="https://github.com/user-attachments/assets/9865312b-8981-49cb-b0d9-36018c36df4b" />| 