### PR TITLE
Fixes the smeltry temperature texture

### DIFF
--- a/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
+++ b/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
@@ -275,7 +275,7 @@ public class SmelteryGui extends ActiveContainerGui {
             int slotTemp = logic.getTempForSlot(iter + slotPos * columns) - 20;
             int maxTemp = logic.getMeltingPointForSlot(iter + slotPos * columns) - 20;
             if (slotTemp > 0 && maxTemp > 0) {
-                int size = 16 * slotTemp / maxTemp + 1;
+                int size = Math.max(1, Math.min(16, 16 * slotTemp / maxTemp));
                 drawTexturedModalRect(
                         cornerX - xleft + (iter % columns * 22),
                         cornerY + 8 + (iter / columns * 18) + 16 - size,


### PR DESCRIPTION
The temperature texture bar is 3x16, sometimes it could overflow 1px to top. Which will results in taking part of the scrollbar texture.

<img width="455" height="779" alt="Dim" src="https://github.com/user-attachments/assets/1fb66a06-1713-4d6a-9f26-e3e9566375e0" />


| Before | After |
| - | - |
| <img width="240" height="155" alt="Pre" src="https://github.com/user-attachments/assets/29f2f922-27fa-479c-8de8-a76ccc22f294" /> | <img width="246" height="166" alt="Post" src="https://github.com/user-attachments/assets/c143fc2a-4b39-4e5d-a364-78f3b702a1b3" /> |



