### PR TITLE
Prevent slime channel from voiding when block is placed on it

### DIFF
--- a/src/main/java/tconstruct/world/blocks/ConveyorBase.java
+++ b/src/main/java/tconstruct/world/blocks/ConveyorBase.java
@@ -29,7 +29,8 @@ public class ConveyorBase extends MantleBlock {
         texturename = name;
     }
 
-    public boolean isBlockReplaceable(World world, int x, int y, int z) {
+    @Override
+    public boolean isReplaceable(IBlockAccess world, int x, int y, int z) {
         return false;
     }
 


### PR DESCRIPTION
This PR prevents slime channels from accidentally being voided when blocks are placed on them. Now, attempting to place a block on them will place it someplace else, similar to the behaviour of slabs. Looking at the code, this was certainly intended, but the wrong method was referenced, so the replaceability override was not done correctly.

<img width="2560" height="1600" alt="Screenshot 2026-05-13 at 1 10 19 AM" src="https://github.com/user-attachments/assets/d91b5125-fd52-4872-9140-efd067705f79" />

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24586