### PR TITLE
Fix main Inventory Tab render logic

### DIFF
--- a/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
+++ b/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
@@ -4,6 +4,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
+import tconstruct.util.config.PHConstruct;
+
 public class InventoryTabVanilla extends AbstractTab {
 
     public InventoryTabVanilla() {
@@ -17,7 +19,19 @@ public class InventoryTabVanilla extends AbstractTab {
 
     @Override
     public boolean shouldAddToList() {
-        return true;
+        if (PHConstruct.enableTinkerInventoryTab) {
+            return true;
+        }
+        for (AbstractTab tab : TabRegistry.getTabList()) {
+            if (tab == this) {
+                continue;
+            }
+            if (tab.shouldAddToList() && !(tab instanceof InventoryTabVanilla)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
+++ b/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
@@ -26,7 +26,7 @@ public class InventoryTabVanilla extends AbstractTab {
             if (tab == this) {
                 continue;
             }
-            if (tab.shouldAddToList() && !(tab instanceof InventoryTabVanilla)) {
+            if (!(tab instanceof InventoryTabVanilla) && tab.shouldAddToList()) {
                 return true;
             }
         }

--- a/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
+++ b/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
@@ -4,8 +4,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
-import tconstruct.util.config.PHConstruct;
-
 public class InventoryTabVanilla extends AbstractTab {
 
     public InventoryTabVanilla() {
@@ -19,16 +17,7 @@ public class InventoryTabVanilla extends AbstractTab {
 
     @Override
     public boolean shouldAddToList() {
-        if (PHConstruct.enableTinkerInventoryTab) {
-            return true;
-        }
-        for (AbstractTab tab : TabRegistry.getTabList()) {
-            if (!(tab instanceof InventoryTabVanilla) && tab.shouldAddToList()) {
-                return true;
-            }
-        }
-
-        return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
+++ b/src/main/java/tconstruct/client/tabs/InventoryTabVanilla.java
@@ -23,9 +23,6 @@ public class InventoryTabVanilla extends AbstractTab {
             return true;
         }
         for (AbstractTab tab : TabRegistry.getTabList()) {
-            if (tab == this) {
-                continue;
-            }
             if (!(tab instanceof InventoryTabVanilla) && tab.shouldAddToList()) {
                 return true;
             }

--- a/src/main/java/tconstruct/client/tabs/TabRegistry.java
+++ b/src/main/java/tconstruct/client/tabs/TabRegistry.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.network.play.client.C0DPacketCloseWindow;
 import net.minecraftforge.client.event.GuiScreenEvent;
@@ -63,11 +64,18 @@ public class TabRegistry {
         }
     }
 
-    public static void addTabsToList(List buttonList) {
+    public static void addTabsToList(List<GuiButton> buttonList) {
+        ArrayList<AbstractTab> tabsToAdd = new ArrayList<>();
+
         for (AbstractTab tab : tabList) {
             if (tab.shouldAddToList()) {
-                buttonList.add(tab);
+                tabsToAdd.add(tab);
             }
+        }
+
+        // If there's only one tab we don't need tabs at all
+        if (tabsToAdd.size() > 1) {
+            buttonList.addAll(tabsToAdd);
         }
     }
 


### PR DESCRIPTION
If the Tinker tab is disabled, still show the main inventory tab when any other mod registers a different tab, so the main tab isn't left alone while other tabs are rendered.

Dev:
<img width="440" height="449" alt="Dev" src="https://github.com/user-attachments/assets/5406e96d-916d-4178-acb1-d5c6cb475636" />

Fullpack:
<img width="303" height="334" alt="Fullpack" src="https://github.com/user-attachments/assets/5b8968b7-d188-4f56-85ac-3c4e9ce50822" />

Fixes https://github.com/GTNewHorizons/TinkersConstruct/issues/287