### PR TITLE
Default whitelist mode to true for slime islands and ore bushes

### DIFF
--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -314,9 +314,9 @@ public class PHConstruct {
         slimeIslUseWhiteList = config.get(
                 "DimBlacklist",
                 "SlimeIslandUseWhitelist",
-                false,
+                true,
                 "True: slime islands only generate in dimensions listed in SlimeIslandDimWhitelist; False: use blacklist behavior")
-                .getBoolean(false);
+                .getBoolean(true);
         cfgDimWhiteList = config.get(
                 "DimBlacklist",
                 "SlimeIslandDimWhitelist",
@@ -326,9 +326,9 @@ public class PHConstruct {
         oreBushUseWhiteList = config.get(
                 "DimBlacklist",
                 "OreBushUseWhitelist",
-                false,
+                true,
                 "True: ore berry bushes only generate in dimensions listed in OreBushDimWhitelist; False: use isSurfaceWorld() check")
-                .getBoolean(false);
+                .getBoolean(true);
         cfgOreBushWhiteList = config.get(
                 "DimBlacklist",
                 "OreBushDimWhitelist",


### PR DESCRIPTION
Whitelist support was added in #281 with defaults set to false to avoid breaking existing behavior. Since slime islands and ore bushes are only intended for the overworld, true is the better default. Packs with many custom dimensions no longer need to manually blacklist each one.