### PR TITLE
Fix crash when repairing or upgrading tools

### DIFF
--- a/src/main/java/tconstruct/library/crafting/ModifyBuilder.java
+++ b/src/main/java/tconstruct/library/crafting/ModifyBuilder.java
@@ -20,6 +20,9 @@ public class ModifyBuilder {
         if (copy.getItem() instanceof IModifyable) {
             IModifyable item = (IModifyable) copy.getItem();
 
+            // Strip stale ToRemove tags that can cause extra amount of items being used or OOB crash
+            copy.getTagCompound().getCompoundTag(item.getBaseTagName()).removeTag("ToRemove");
+
             boolean built = false;
             for (ItemModifier mod : itemModifiers) {
                 if (mod.matches(modifiers, input) && mod.validType(item)) {

--- a/src/main/java/tconstruct/tools/inventory/CraftingStationContainer.java
+++ b/src/main/java/tconstruct/tools/inventory/CraftingStationContainer.java
@@ -317,7 +317,11 @@ public class CraftingStationContainer extends Container {
                 copyStack = otherInventorySlot.getStack();
 
                 if (copyStack == null && otherInventorySlot.isItemValid(stack)) {
-                    otherInventorySlot.putStack(stack.copy());
+                    ItemStack placed = stack.copy();
+                    if (placed.hasTagCompound() && placed.getItem() instanceof IModifyable modifyable) {
+                        placed.getTagCompound().getCompoundTag(modifyable.getBaseTagName()).removeTag("ToRemove");
+                    }
+                    otherInventorySlot.putStack(placed);
                     otherInventorySlot.onSlotChanged();
                     stack.stackSize = 0;
                     failedToMerge = true;

--- a/src/main/java/tconstruct/tools/inventory/SlotCraftingStation.java
+++ b/src/main/java/tconstruct/tools/inventory/SlotCraftingStation.java
@@ -31,13 +31,13 @@ public class SlotCraftingStation extends SlotCrafting {
             int toRemoveIndex = 0;
             IInventory inventory = this.matrix;
 
-            for (int i = 0; i <= inventory.getSizeInventory(); i++) {
+            for (int i = 0; i < inventory.getSizeInventory(); i++) {
                 if (i == 4) continue;
                 ItemStack item = inventory.getStackInSlot(i);
                 if (item == null) {
                     continue;
                 }
-                if (toRemoveArray == null) {
+                if (toRemoveArray == null || toRemoveIndex >= toRemoveArray.length) {
                     inventory.decrStackSize(i, 1);
                 } else {
                     inventory.decrStackSize(i, toRemoveArray[toRemoveIndex]);

--- a/src/main/java/tconstruct/tools/inventory/SlotTool.java
+++ b/src/main/java/tconstruct/tools/inventory/SlotTool.java
@@ -64,7 +64,7 @@ public class SlotTool extends Slot {
                 if (item == null) {
                     continue;
                 }
-                if (toRemoveArray == null) {
+                if (toRemoveArray == null || toRemoveIndex >= toRemoveArray.length) {
                     inventory.decrStackSize(i, 1);
                 } else {
                     inventory.decrStackSize(i, toRemoveArray[toRemoveIndex]);

--- a/src/main/java/tconstruct/tools/inventory/SlotToolForge.java
+++ b/src/main/java/tconstruct/tools/inventory/SlotToolForge.java
@@ -35,7 +35,7 @@ public class SlotToolForge extends SlotTool {
                 if (item == null) {
                     continue;
                 }
-                if (toRemoveArray == null) {
+                if (toRemoveArray == null || toRemoveIndex >= toRemoveArray.length) {
                     inventory.decrStackSize(i, 1);
                 } else {
                     inventory.decrStackSize(i, toRemoveArray[toRemoveIndex]);

--- a/src/main/java/tconstruct/tools/inventory/ToolForgeContainer.java
+++ b/src/main/java/tconstruct/tools/inventory/ToolForgeContainer.java
@@ -84,7 +84,7 @@ public class ToolForgeContainer extends ToolStationContainer {
                 if (item == null) {
                     continue;
                 }
-                if (toRemoveArray == null) {
+                if (toRemoveArray == null || toRemoveIndex >= toRemoveArray.length) {
                     logic.decrStackSize(i, 1);
                 } else {
                     logic.decrStackSize(i, toRemoveArray[toRemoveIndex]);

--- a/src/main/java/tconstruct/tools/inventory/ToolStationContainer.java
+++ b/src/main/java/tconstruct/tools/inventory/ToolStationContainer.java
@@ -133,7 +133,7 @@ public class ToolStationContainer extends ActiveContainer {
                 if (item == null) {
                     continue;
                 }
-                if (toRemoveArray == null) {
+                if (toRemoveArray == null || toRemoveIndex >= toRemoveArray.length) {
                     logic.decrStackSize(i, 1);
                 } else {
                     logic.decrStackSize(i, toRemoveArray[toRemoveIndex]);


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25043
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25570

Regression caused by https://github.com/GTNewHorizons/TinkersConstruct/pull/294

Add length check to avoid OOB crash
Add striping of stale tag to both treat the source and also avoid extra consumption of items as reported in some of the issues closed as duplicate of this.
Also try to ensure the tag doesn't end up on new items.