### PR TITLE
Extend ColorUtils and bump GTNHLib

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("com.github.GTNewHorizons:Mantle:0.5.3:dev")
     api("com.github.GTNewHorizons:ForgeMultipart:1.7.10:dev")
     // gtnhlib is compileOnlyApi by us, but needed at runtime by nei, so require the correct version
-    api("com.github.GTNewHorizons:GTNHLib:0.11.16:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.11.30:dev")
     implementation("com.github.GTNewHorizons:NotEnoughItems:2.8.103-GTNH:dev")
     compileOnlyApi("curse.maven:cofh-core-69162:2388751")
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:api")

--- a/src/main/java/tconstruct/library/util/ColorUtils.java
+++ b/src/main/java/tconstruct/library/util/ColorUtils.java
@@ -23,6 +23,7 @@ public class ColorUtils {
         materialBowDrawSpeed        = color.rgb("materialBowDrawSpeed",         "0x404040"),
         materialBowFlightSpeedMax   = color.rgb("materialBowFlightSpeedMax",    "0x404040"),
         materialArrowMass           = color.rgb("materialArrowMass",            "0x404040"),
-        materialArrowBreakChance    = color.rgb("materialArrowBreakChance",     "0x404040");
+        materialArrowBreakChance    = color.rgb("materialArrowBreakChance",     "0x404040"),
+        neiTemperature              = color.rgb("neiTemperature",               "0x808080");
     // spotless:on
 }

--- a/src/main/java/tconstruct/plugins/nei/RecipeHandlerMelting.java
+++ b/src/main/java/tconstruct/plugins/nei/RecipeHandlerMelting.java
@@ -18,6 +18,7 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import mantle.utils.ItemMetaWrapper;
 import tconstruct.library.crafting.Smeltery;
+import tconstruct.library.util.ColorUtils;
 
 public class RecipeHandlerMelting extends RecipeHandlerBase {
 
@@ -91,7 +92,7 @@ public class RecipeHandlerMelting extends RecipeHandlerBase {
     @Override
     public void drawExtras(int recipe) {
         int temperature = ((CachedMeltingRecipe) this.arecipes.get(recipe)).temperature;
-        GuiDraw.drawStringC(temperature + " C", 81, 9, 0x808080, false);
+        GuiDraw.drawStringC(temperature + " C", 81, 9, ColorUtils.neiTemperature.getColor(), false);
     }
 
     @Override


### PR DESCRIPTION
## Summary
Adds one new color and bumps the GTNHLib Dep version (with updated ColorResource class)


## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
