### PR TITLE
add purity and oreberry tooltips from customtooltip

### DIFF
--- a/src/main/java/tconstruct/smeltery/itemblocks/CastingChannelItem.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/CastingChannelItem.java
@@ -1,6 +1,11 @@
 package tconstruct.smeltery.itemblocks;
 
+import java.util.List;
+
 import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.StatCollector;
 
 import mantle.blocks.abstracts.MultiItemBlock;
 
@@ -12,5 +17,10 @@ public class CastingChannelItem extends MultiItemBlock {
         super(b, "Smeltery", blockTypes);
         setMaxDamage(0);
         setHasSubtypes(true);
+    }
+
+    @Override
+    public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean par4) {
+        list.add(StatCollector.translateToLocal("smeltery.purity.tooltip"));
     }
 }

--- a/src/main/java/tconstruct/smeltery/itemblocks/LavaTankItemBlock.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/LavaTankItemBlock.java
@@ -37,6 +37,8 @@ public class LavaTankItemBlock extends MultiItemBlock implements IFluidContainer
             list.add(StatCollector.translateToLocal("searedtank3.tooltip"));
             list.add(StatCollector.translateToLocal("searedtank2.tooltip"));
         }
+
+        list.add(StatCollector.translateToLocal("smeltery.purity.tooltip"));
     }
 
     /**

--- a/src/main/java/tconstruct/smeltery/itemblocks/SearedTableItemBlock.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/SearedTableItemBlock.java
@@ -35,5 +35,7 @@ public class SearedTableItemBlock extends MultiItemBlock {
         }
 
         if (StatCollector.canTranslate(tooltip)) p_77624_3_.add(StatCollector.translateToLocal(tooltip));
+
+        p_77624_3_.add(StatCollector.translateToLocal("smeltery.purity.tooltip"));
     }
 }

--- a/src/main/java/tconstruct/smeltery/itemblocks/SmelteryItemBlock.java
+++ b/src/main/java/tconstruct/smeltery/itemblocks/SmelteryItemBlock.java
@@ -30,10 +30,12 @@ public class SmelteryItemBlock extends MultiItemBlock {
         switch (stack.getItemDamage()) {
             case 0:
                 list.add(StatCollector.translateToLocal("smeltery.controller.tooltip"));
+                list.add(StatCollector.translateToLocal("smeltery.purity.tooltip"));
                 break;
             case 1:
                 list.add(StatCollector.translateToLocal("smeltery.drain.tooltip1"));
                 list.add(StatCollector.translateToLocal("smeltery.drain.tooltip2"));
+                list.add(StatCollector.translateToLocal("smeltery.purity.tooltip"));
                 break;
             case 3:
                 list.add(StatCollector.translateToLocal("smeltery.furnace.tooltip"));

--- a/src/main/java/tconstruct/world/items/OreBerries.java
+++ b/src/main/java/tconstruct/world/items/OreBerries.java
@@ -50,6 +50,8 @@ public class OreBerries extends CraftingItem {
                 list.add(StatCollector.translateToLocal("oreberries6.tooltip"));
                 break;
         }
+
+        list.add(StatCollector.translateToLocal("oreberries.crops.tooltip"));
     }
 
     @Override

--- a/src/main/resources/assets/tinker/lang/en_US.lang
+++ b/src/main/resources/assets/tinker/lang/en_US.lang
@@ -825,6 +825,7 @@ oreberries3.tooltip=Tastes like metal
 oreberries4.tooltip=Tin Man
 oreberries5.tooltip=White Chocolate
 oreberries6.tooltip=Tastes like Creeper
+oreberries.crops.tooltip=Can be placed on empty Crop Sticks. See their growth requirements in NEI.
 item.crafting.tooltip=Crafting Item
 item.accessory.tooltip=Accessory
 canister.tooltip=Permanent health increase
@@ -859,6 +860,7 @@ smeltery.brick.tooltip2=(Safe for decoration)
 smeltery.castingtable.tooltip=Basic Smeltery equipment
 smeltery.castingfaucet.tooltip=This Smeltery is leaking
 smeltery.castingbasin.tooltip=For the ambitious Smeltery
+smeltery.purity.tooltip=§3Some metals processed in smeltery don't meet the purity requirement for GregTech processing.
 craftingstation.dump_button.tooltip=Dump grid content to linked inventory
 #Dear translators, only translate these lines if the jokes are applicable in your language.
 grout.tooltip=I am Grout!

--- a/src/main/resources/assets/tinker/lang/ru_RU.lang
+++ b/src/main/resources/assets/tinker/lang/ru_RU.lang
@@ -742,6 +742,7 @@ oreberries3.tooltip=На вкус, как металл
 oreberries4.tooltip=Оловянный человек
 oreberries5.tooltip=Белый шоколад
 oreberries6.tooltip=На вкус, как крипер
+oreberries.crops.tooltip=Можно посадить на пустые жёрдочки. Условия роста смотрите в NEI.
 item.crafting.tooltip=Участвует в создании
 item.accessory.tooltip=Аксессуар
 canister.tooltip=Постоянная прибавка к здоровью
@@ -776,6 +777,7 @@ smeltery.brick.tooltip2=(Безопасен для декораций)
 smeltery.castingtable.tooltip=Основное оборудование плавильни
 smeltery.castingfaucet.tooltip=Эта плавильня протекает
 smeltery.castingbasin.tooltip=Для амбициозной плавильни
+smeltery.purity.tooltip=§3Часть металлов, переработанных в плавильне, не соответствует требованиям GregTech по чистоте.
 #Dear translators, only translate these lines if the jokes are applicable in your language.
 grout.tooltip=Я есть цемент!
 frypankill.tooltip=Это бедное животное встретило свою кончину во время громкого *удара*


### PR DESCRIPTION
## Summary
These tooltips were maintained externally through CustomTooltips config, which meant every pack had to carry the same entries. Moving them into the mod keeps them with the blocks they describe and makes them translatable through the regular lang files.

Purity warning goes on the Smeltery Controller, Drain, all three Seared Tank variants, the casting table, faucet, basin, and the Casting Channel.

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
