### PR TITLE
Fix AOE tool hit face desync

### DIFF
--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -51,6 +51,7 @@ import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.Detailing;
 import tconstruct.library.crafting.LiquidCasting;
 import tconstruct.library.util.AoEExclusionList;
+import tconstruct.library.util.BlockSideHitListener;
 import tconstruct.mechworks.TinkerMechworks;
 import tconstruct.mechworks.landmine.behavior.Behavior;
 import tconstruct.mechworks.landmine.behavior.stackCombo.SpecialStackHandler;
@@ -196,6 +197,7 @@ public class TConstruct {
         chiselDetailing = new Detailing();
 
         AoEExclusionList.init(new File(event.getModConfigurationDirectory(), "TConstruct_AOEExclusions.cfg"));
+        BlockSideHitListener.init();
 
         playerTracker = new TPlayerHandler();
         NetworkRegistry.INSTANCE.registerGuiHandler(TConstruct.instance, proxy);

--- a/src/main/java/tconstruct/items/tools/Scythe.java
+++ b/src/main/java/tconstruct/items/tools/Scythe.java
@@ -6,7 +6,6 @@ import java.util.Random;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -28,6 +27,7 @@ import tconstruct.library.ActiveToolMod;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.library.tools.Weapon;
+import tconstruct.library.util.BlockSideHitListener;
 import tconstruct.tools.TinkerTools;
 
 public class Scythe extends Weapon {
@@ -240,16 +240,14 @@ public class Scythe extends Weapon {
                                                                         x,
                                                                         y,
                                                                         z,
-                                                                        Minecraft
-                                                                                .getMinecraft().objectMouseOver.sideHit));
+                                                                        BlockSideHitListener.getSideHit(player)));
                                                         handlerClient.addToSendQueue(
                                                                 new C07PacketPlayerDigging(
                                                                         2,
                                                                         x,
                                                                         y,
                                                                         z,
-                                                                        Minecraft
-                                                                                .getMinecraft().objectMouseOver.sideHit));
+                                                                        BlockSideHitListener.getSideHit(player)));
                                                     }
                                                 }
 

--- a/src/main/java/tconstruct/items/tools/Scythe.java
+++ b/src/main/java/tconstruct/items/tools/Scythe.java
@@ -27,7 +27,6 @@ import tconstruct.library.ActiveToolMod;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.library.tools.Weapon;
-import tconstruct.library.util.BlockSideHitListener;
 import tconstruct.tools.TinkerTools;
 
 public class Scythe extends Weapon {
@@ -234,20 +233,11 @@ public class Scythe extends Weapon {
                                                             .getClientPlayHandler();
                                                     if (handler instanceof NetHandlerPlayClient) {
                                                         NetHandlerPlayClient handlerClient = (NetHandlerPlayClient) handler;
+                                                        // scythe aoe is a cube so the face is irrelevant
                                                         handlerClient.addToSendQueue(
-                                                                new C07PacketPlayerDigging(
-                                                                        0,
-                                                                        x,
-                                                                        y,
-                                                                        z,
-                                                                        BlockSideHitListener.getSideHit(player)));
+                                                                new C07PacketPlayerDigging(0, x, y, z, 1));
                                                         handlerClient.addToSendQueue(
-                                                                new C07PacketPlayerDigging(
-                                                                        2,
-                                                                        x,
-                                                                        y,
-                                                                        z,
-                                                                        BlockSideHitListener.getSideHit(player)));
+                                                                new C07PacketPlayerDigging(2, x, y, z, 1));
                                                     }
                                                 }
 

--- a/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
@@ -26,6 +26,8 @@ public abstract class AOEHarvestTool extends HarvestTool {
 
     @Override
     public boolean onBlockStartBreak(ItemStack stack, int x, int y, int z, EntityPlayer player) {
+        if (player.worldObj.isRemote) return super.onBlockStartBreak(stack, x, y, z, player);
+
         // only effective materials matter. We don't want to aoe when breaking dirt with a hammer.
         String toolName = "tool." + getAOEToolName().toLowerCase();
         Block block = player.worldObj.getBlock(x, y, z);

--- a/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/AOEHarvestTool.java
@@ -4,9 +4,9 @@ import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.MovingObjectPosition;
 
 import tconstruct.library.util.AoEExclusionList;
+import tconstruct.library.util.BlockSideHitListener;
 
 public abstract class AOEHarvestTool extends HarvestTool {
 
@@ -39,10 +39,7 @@ public abstract class AOEHarvestTool extends HarvestTool {
 
         if (player.isSneaking()) return super.onBlockStartBreak(stack, x, y, z, player);
 
-        MovingObjectPosition mop = AbilityHelper.raytraceFromEntity(player.worldObj, player, false, 4.5d);
-        if (mop == null) return super.onBlockStartBreak(stack, x, y, z, player);
-        int sideHit = mop.sideHit;
-        // int sideHit = Minecraft.getMinecraft().objectMouseOver.sideHit;
+        int sideHit = BlockSideHitListener.getSideHit(player);
 
         // we successfully destroyed a block. time to do AOE!
         int xRange = breakRadius;

--- a/src/main/java/tconstruct/library/tools/HarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/HarvestTool.java
@@ -303,8 +303,8 @@ public abstract class HarvestTool extends ToolCore {
             }
 
             // send an update to the server, so we get an update back
-            if (PHConstruct.extraBlockUpdates) Minecraft.getMinecraft().getNetHandler().addToSendQueue(
-                    new C07PacketPlayerDigging(2, x, y, z, Minecraft.getMinecraft().objectMouseOver.sideHit));
+            if (PHConstruct.extraBlockUpdates) Minecraft.getMinecraft().getNetHandler()
+                    .addToSendQueue(new C07PacketPlayerDigging(2, x, y, z, sidehit));
         }
     }
 }

--- a/src/main/java/tconstruct/library/util/BlockSideHitListener.java
+++ b/src/main/java/tconstruct/library/util/BlockSideHitListener.java
@@ -1,0 +1,62 @@
+package tconstruct.library.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent;
+
+/** Logic to keep track of the side of the block that was last hit. */
+public class BlockSideHitListener {
+
+    private static final Map<UUID, Integer> HIT_FACE = new HashMap<>();
+    private static int clientSideHit = 1;
+    private static boolean initialized = false;
+
+    /** Initializes this listener. */
+    public static void init() {
+        if (initialized) return;
+
+        initialized = true;
+        BlockSideHitListener listener = new BlockSideHitListener();
+        MinecraftForge.EVENT_BUS.register(listener);
+        FMLCommonHandler.instance().bus().register(listener);
+    }
+
+    /** Called when the player left-clicks a block to store the face. */
+    @SubscribeEvent
+    public void onLeftClickBlock(PlayerInteractEvent event) {
+        if (event.action == PlayerInteractEvent.Action.LEFT_CLICK_BLOCK) {
+            EntityPlayer player = event.entityPlayer;
+            if (player.worldObj.isRemote) {
+                clientSideHit = event.face;
+            } else {
+                HIT_FACE.put(player.getUniqueID(), event.face);
+            }
+        }
+    }
+
+    /** Called when a player leaves the server to clear the face. */
+    @SubscribeEvent
+    public void onLeaveServer(PlayerLoggedOutEvent event) {
+        HIT_FACE.remove(event.player.getUniqueID());
+    }
+
+    /**
+     * Gets the side this player last hit.
+     *
+     * @param player player whose last hit side is requested
+     * @return side last hit
+     */
+    public static int getSideHit(EntityPlayer player) {
+        if (player.worldObj.isRemote) return clientSideHit;
+        Integer side = HIT_FACE.get(player.getUniqueID());
+        return side == null ? 1 : side;
+    }
+}

--- a/src/main/java/tconstruct/library/util/BlockSideHitListener.java
+++ b/src/main/java/tconstruct/library/util/BlockSideHitListener.java
@@ -16,7 +16,6 @@ import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent;
 public class BlockSideHitListener {
 
     private static final Map<UUID, Integer> HIT_FACE = new HashMap<>();
-    private static int clientSideHit = 1;
     private static boolean initialized = false;
 
     /** Initializes this listener. */
@@ -33,12 +32,7 @@ public class BlockSideHitListener {
     @SubscribeEvent
     public void onLeftClickBlock(PlayerInteractEvent event) {
         if (event.action == PlayerInteractEvent.Action.LEFT_CLICK_BLOCK) {
-            EntityPlayer player = event.entityPlayer;
-            if (player.worldObj.isRemote) {
-                clientSideHit = event.face;
-            } else {
-                HIT_FACE.put(player.getUniqueID(), event.face);
-            }
+            HIT_FACE.put(event.entityPlayer.getUniqueID(), event.face);
         }
     }
 
@@ -55,7 +49,6 @@ public class BlockSideHitListener {
      * @return side last hit
      */
     public static int getSideHit(EntityPlayer player) {
-        if (player.worldObj.isRemote) return clientSideHit;
         Integer side = HIT_FACE.get(player.getUniqueID());
         return side == null ? 1 : side;
     }


### PR DESCRIPTION
## Summary

fixes a desync where aoe tools break blocks in a different direction than intended if the server lags and the player turns their camera while mining

basically a backport of the [upstream fix](https://github.com/SlimeKnights/TinkersConstruct/commit/13e1b2552fb5d5f8a5d518c28f4369f35fc3c356)

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
