### PR TITLE
Add null guard for windup progress check

### DIFF
--- a/src/main/java/tconstruct/weaponry/client/CrosshairHandler.java
+++ b/src/main/java/tconstruct/weaponry/client/CrosshairHandler.java
@@ -70,7 +70,7 @@ public class CrosshairHandler {
         GL11.glEnable(GL11.GL_BLEND);
         OpenGlHelper.glBlendFunc(GL11.GL_ONE_MINUS_DST_COLOR, GL11.GL_ONE_MINUS_SRC_COLOR, 1, 0);
 
-        if(equipped.getTagCompound() == null) return;
+        if (equipped.getTagCompound() == null) return;
         float spread = ((1.0f - weapon.getWindupProgress(equipped, mc.thePlayer)) * 25f);
 
         // 4 square crosshair

--- a/src/main/java/tconstruct/weaponry/client/CrosshairHandler.java
+++ b/src/main/java/tconstruct/weaponry/client/CrosshairHandler.java
@@ -70,6 +70,7 @@ public class CrosshairHandler {
         GL11.glEnable(GL11.GL_BLEND);
         OpenGlHelper.glBlendFunc(GL11.GL_ONE_MINUS_DST_COLOR, GL11.GL_ONE_MINUS_SRC_COLOR, 1, 0);
 
+        if(equipped.getTagCompound() == null) return;
         float spread = ((1.0f - weapon.getWindupProgress(equipped, mc.thePlayer)) * 25f);
 
         // 4 square crosshair


### PR DESCRIPTION
## Summary
This PR fixes a NullPointerException that happens if the `getCompoundTag` method of the TiCon crossbow item returns null when checking the windup progress immediately after the crossbow is taken from the blood magic altar.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26303


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
