### PR TITLE
change damage behavior to vanilla

### DIFF
--- a/src/main/java/tconstruct/library/tools/AbilityHelper.java
+++ b/src/main/java/tconstruct/library/tools/AbilityHelper.java
@@ -54,7 +54,7 @@ public class AbilityHelper {
         if (tags.getCompoundTag("InfiTool").hasKey("Unbreaking"))
             reinforced = tags.getCompoundTag("InfiTool").getInteger("Unbreaking");
 
-        if (random.nextInt(10) < 10 - reinforced) {
+        if (random.nextInt(10) < 10 - reinforced && (double) block.getBlockHardness(world, x, y, z) != 0.0D) {
             damageTool(stack, 1, tags, player, false);
         }
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26310
the root cause of this issue is from the override `onBlockDestroyed()` method's behavior not in line with vanilla, which did not check the hardness of the block to be broken. now it is fixed as what vanilla Minecraft do

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
