### PR TITLE
Hitbox change

### DIFF
--- a/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
@@ -295,14 +295,8 @@ public class LavaTankBlock extends BlockContainer {
     }
 
     @Override
-    public void addCollisionBoxesToList(
-            World world,
-            int x,
-            int y,
-            int z,
-            AxisAlignedBB entityBox,
-            List<AxisAlignedBB> list,
-            Entity entity) {
+    public void addCollisionBoxesToList(World world, int x, int y, int z, AxisAlignedBB entityBox,
+            List<AxisAlignedBB> list, Entity entity) {
 
         super.addCollisionBoxesToList(world, x, y, z, entityBox, list, entity);
 

--- a/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
@@ -7,12 +7,14 @@ import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -289,6 +291,31 @@ public class LavaTankBlock extends BlockContainer {
         if (liquid != null) {
             LavaTankLogic logic = (LavaTankLogic) world.getTileEntity(x, y, z);
             logic.tank.setFluid(liquid);
+        }
+    }
+
+    @Override
+    public void addCollisionBoxesToList(
+            World world,
+            int x,
+            int y,
+            int z,
+            AxisAlignedBB entityBox,
+            List<AxisAlignedBB> list,
+            Entity entity) {
+
+        super.addCollisionBoxesToList(world, x, y, z, entityBox, list, entity);
+
+        AxisAlignedBB extraBox = AxisAlignedBB.getBoundingBox(
+                x + 3.0 / 16.0,
+                y + 1.0,
+                z + 3.0 / 16.0,
+                x + 13.0 / 16.0,
+                y + 18.0 / 16.0,
+                z + 13.0 / 16.0);
+
+        if (entityBox.intersectsWith(extraBox)) {
+            list.add(extraBox);
         }
     }
 

--- a/src/main/java/tconstruct/tools/blocks/CraftingSlab.java
+++ b/src/main/java/tconstruct/tools/blocks/CraftingSlab.java
@@ -72,14 +72,6 @@ public class CraftingSlab extends InventorySlab {
 
     @Override
     public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
-        int metadata = world.getBlockMetadata(x, y, z);
-        if (metadata == 5 || metadata == 6) return AxisAlignedBB.getBoundingBox(
-                (double) x + this.minX,
-                (double) y + this.minY,
-                (double) z + this.minZ,
-                (double) x + this.maxX,
-                (double) y + this.maxY - 0.125,
-                (double) z + this.maxZ);
         return AxisAlignedBB.getBoundingBox(
                 (double) x + this.minX,
                 (double) y + this.minY,

--- a/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
@@ -114,9 +114,7 @@ public class ToolStationBlock extends InventoryBlock {
     }
 
     @Override
-    public MovingObjectPosition collisionRayTrace(
-            World world, int x, int y, int z,
-            Vec3 start, Vec3 end) {
+    public MovingObjectPosition collisionRayTrace(World world, int x, int y, int z, Vec3 start, Vec3 end) {
 
         int metadata = world.getBlockMetadata(x, y, z);
 
@@ -128,15 +126,11 @@ public class ToolStationBlock extends InventoryBlock {
             float oldMaxY = (float) this.maxY;
             float oldMaxZ = (float) this.maxZ;
 
-            this.setBlockBounds(
-                    0.0F, 0.0F, 0.0F,
-                    1.0F, 0.875F, 1.0F);
+            this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.875F, 1.0F);
 
             MovingObjectPosition result = collisionRayTrace(world, x, y, z, start, end);
 
-            this.setBlockBounds(
-                    oldMinX, oldMinY, oldMinZ,
-                    oldMaxX, oldMaxY, oldMaxZ);
+            this.setBlockBounds(oldMinX, oldMinY, oldMinZ, oldMaxX, oldMaxY, oldMaxZ);
 
             return result;
         }
@@ -164,22 +158,13 @@ public class ToolStationBlock extends InventoryBlock {
     }
 
     @Override
-    public void addCollisionBoxesToList(
-            World world, int x, int y, int z,
-            AxisAlignedBB mask,
-            List<AxisAlignedBB> list,
+    public void addCollisionBoxesToList(World world, int x, int y, int z, AxisAlignedBB mask, List<AxisAlignedBB> list,
             Entity entity) {
 
         int metadata = world.getBlockMetadata(x, y, z);
 
         if (metadata == 5 || metadata == 6) {
-            AxisAlignedBB box = AxisAlignedBB.getBoundingBox(
-                    x,
-                    y,
-                    z,
-                    x + 1,
-                    y + 0.875,
-                    z + 1);
+            AxisAlignedBB box = AxisAlignedBB.getBoundingBox(x, y, z, x + 1, y + 0.875, z + 1);
 
             if (box.intersectsWith(mask)) {
                 list.add(box);

--- a/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
@@ -128,7 +128,7 @@ public class ToolStationBlock extends InventoryBlock {
 
             this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.875F, 1.0F);
 
-            MovingObjectPosition result = collisionRayTrace(world, x, y, z, start, end);
+            MovingObjectPosition result = super.collisionRayTrace(world, x, y, z, start, end);
 
             this.setBlockBounds(oldMinX, oldMinY, oldMinZ, oldMaxX, oldMaxY, oldMaxZ);
 

--- a/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
@@ -5,6 +5,7 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -127,6 +128,33 @@ public class ToolStationBlock extends InventoryBlock {
                 (double) x + this.maxX,
                 (double) y + this.maxY,
                 (double) z + this.maxZ);
+    }
+
+    @Override
+    public void addCollisionBoxesToList(
+            World world, int x, int y, int z,
+            AxisAlignedBB mask,
+            List<AxisAlignedBB> list,
+            Entity entity) {
+
+        int metadata = world.getBlockMetadata(x, y, z);
+
+        if (metadata == 5 || metadata == 6) {
+            AxisAlignedBB box = AxisAlignedBB.getBoundingBox(
+                    x,
+                    y,
+                    z,
+                    x + 1,
+                    y + 0.875,
+                    z + 1);
+
+            if (box.intersectsWith(mask)) {
+                list.add(box);
+            }
+            return;
+        }
+
+        super.addCollisionBoxesToList(world, x, y, z, mask, list, entity);
     }
 
     @Override

--- a/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
+++ b/src/main/java/tconstruct/tools/blocks/ToolStationBlock.java
@@ -15,6 +15,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -109,6 +111,37 @@ public class ToolStationBlock extends InventoryBlock {
     @Override
     public boolean shouldSideBeRendered(IBlockAccess par1IBlockAccess, int par2, int par3, int par4, int par5) {
         return true;
+    }
+
+    @Override
+    public MovingObjectPosition collisionRayTrace(
+            World world, int x, int y, int z,
+            Vec3 start, Vec3 end) {
+
+        int metadata = world.getBlockMetadata(x, y, z);
+
+        if (metadata == 5 || metadata == 6) {
+            float oldMinX = (float) this.minX;
+            float oldMinY = (float) this.minY;
+            float oldMinZ = (float) this.minZ;
+            float oldMaxX = (float) this.maxX;
+            float oldMaxY = (float) this.maxY;
+            float oldMaxZ = (float) this.maxZ;
+
+            this.setBlockBounds(
+                    0.0F, 0.0F, 0.0F,
+                    1.0F, 0.875F, 1.0F);
+
+            MovingObjectPosition result = collisionRayTrace(world, x, y, z, start, end);
+
+            this.setBlockBounds(
+                    oldMinX, oldMinY, oldMinZ,
+                    oldMaxX, oldMaxY, oldMaxZ);
+
+            return result;
+        }
+
+        return super.collisionRayTrace(world, x, y, z, start, end);
     }
 
     @Override


### PR DESCRIPTION
## Summary
Changes some hitboxes to reflect models more accurately.

Old:
<img width="416" height="674" alt="image" src="https://github.com/user-attachments/assets/f3fc05e8-d372-422d-bec0-eda7063728c2" />

<img width="436" height="681" alt="image" src="https://github.com/user-attachments/assets/e8977f80-bf99-442c-9467-30c3fe1ccc16" />

<img width="639" height="604" alt="image" src="https://github.com/user-attachments/assets/dbae314a-8740-4afc-96cf-257c17da8b2e" />

New:

<img width="447" height="658" alt="image" src="https://github.com/user-attachments/assets/ee39b139-f38a-4de5-949f-81430e7bae9e" />

<img width="420" height="749" alt="image" src="https://github.com/user-attachments/assets/78d9ad10-b074-478a-8f48-07f60e9ada0a" />

<img width="678" height="534" alt="image" src="https://github.com/user-attachments/assets/47894b03-5ee1-4d18-890e-1b3a50b8e9f9" />


## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
