### PR TITLE
Fix on "fixed quartz modifier not adding attack due to overflow"

### DIFF
--- a/src/main/java/tconstruct/modifiers/tools/ModAttack.java
+++ b/src/main/java/tconstruct/modifiers/tools/ModAttack.java
@@ -91,12 +91,11 @@ public class ModAttack extends ItemModTypeFilter {
 
         if (tags.hasKey(key)) {
             int[] keyPair = tags.getIntArray(key);
-            int overThreshold = increase / threshold;
 
             int leftToBoost = threshold - (keyPair[0] % threshold);
             if (increase >= leftToBoost) {
                 int attack = tags.getInteger("Attack");
-                attack += (overThreshold > 1) ? overThreshold : 1;
+                attack += 1 + (increase - leftToBoost) / threshold;
                 tags.setInteger("Attack", attack);
             }
 
@@ -118,14 +117,13 @@ public class ModAttack extends ItemModTypeFilter {
             int modifiers = tags.getInteger("Modifiers");
             modifiers -= 1;
             tags.setInteger("Modifiers", modifiers);
-            int overThreshold = increase / threshold;
             String modName = "\u00a7f" + guiType + " (" + increase + "/" + max + ")";
             int tooltipIndex = addToolTip(tool, tooltipName, modName);
             int[] keyPair = new int[] { increase, max, tooltipIndex };
             tags.setIntArray(key, keyPair);
 
             int attack = tags.getInteger("Attack");
-            attack += (overThreshold >= 1) ? overThreshold : 0;
+            attack += 1 + (increase / threshold);
             tags.setInteger("Attack", attack);
         }
     }

--- a/src/main/java/tconstruct/modifiers/tools/ModAttack.java
+++ b/src/main/java/tconstruct/modifiers/tools/ModAttack.java
@@ -123,7 +123,7 @@ public class ModAttack extends ItemModTypeFilter {
             tags.setIntArray(key, keyPair);
 
             int attack = tags.getInteger("Attack");
-            attack += 1 + (increase / threshold);
+            attack += 1 + increase / threshold;
             tags.setInteger("Attack", attack);
         }
     }


### PR DESCRIPTION
Originally, the code used 'attack += 1'. This created a risk of accidentally skipping a modifier if the step size exceeded the threshold. The fix implemented by imTheSupremeOne failed to account for the remaining 'leftToBoost' value. Furthermore, he overlooked the fact that the original author always included 'attack += 1' in the initialization block. Had the original author intended to include a check, they would have simply added something like 'if (increase >= threshold)'.

## Summary
<!-- Briefly describe what this PR changes and why. -->
I was just looking through the decompiler to see how tool modifiers work, and a slightly complex piece of code-one that had tripped me up many times-caught my eye.

I was looking at the 'attack++' version.

I calculated that, in some cases, the modifier wouldn't actually increase the damage. I tested this in version 2.8.4, and my suspicions were confirmed.


Before setting out to fix it, I decided to check if it had already been addressed, and I stumbled upon this pull request: "https://github.com/GTNewHorizons/TinkersConstruct/pull/250/changes"

Upon closer inspection, I realized that his corrections didn't actually change anything, and the result remained the same. To make matters worse, the initial improvement was now being lost in the initialization block. I even specifically reviewed the changes made to that particular line in the initialization block; it was originally 'attack += 1', so I had only added logic to handle the overflow.

Unfortunately, I cannot attach screenshots; I am unable to upload them.

To reproduce the issue, simply upgrade the tool using quartz to a level of 144 following two different methods, then compare the damage:
1. Insert each block _individually_.
2. Insert the blocks in batches of 8, 8, 2, 2, 8, and 8 (the order of the batches matters).

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
