### PR TITLE
fix crafting station shift click and adjacent hotbar slot selection

### DIFF
--- a/src/main/java/tconstruct/library/tools/HarvestTool.java
+++ b/src/main/java/tconstruct/library/tools/HarvestTool.java
@@ -131,10 +131,10 @@ public abstract class HarvestTool extends ToolCore {
 
         boolean used = false;
         int hotbarSlot = player.inventory.currentItem;
-        int itemSlot = hotbarSlot == 0 ? 8 : hotbarSlot + 1;
+        int itemSlot = getAdjacentHotbarSlot(hotbarSlot);
         ItemStack nearbyStack;
 
-        if (hotbarSlot < 8) {
+        if (itemSlot >= 0) {
             nearbyStack = player.inventory.getStackInSlot(itemSlot);
             if (nearbyStack != null) {
                 Item item = nearbyStack.getItem();

--- a/src/main/java/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/tconstruct/library/tools/ToolCore.java
@@ -11,6 +11,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemPotion;
 import net.minecraft.item.ItemStack;
@@ -611,11 +612,10 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
 
     @Override
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
-        int hotbarSlot = player.inventory.currentItem;
-        int itemSlot = hotbarSlot == 0 ? 8 : hotbarSlot + 1;
+        int itemSlot = getAdjacentHotbarSlot(player.inventory.currentItem);
         ItemStack nearbyStack;
 
-        if (hotbarSlot < 8) {
+        if (itemSlot >= 0) {
             nearbyStack = player.inventory.getStackInSlot(itemSlot);
             if (nearbyStack != null) {
                 Item item = nearbyStack.getItem();
@@ -634,6 +634,10 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
             }
         }
         return stack;
+    }
+
+    protected int getAdjacentHotbarSlot(int hotbarSlot) {
+        return hotbarSlot < InventoryPlayer.getHotbarSize() - 1 ? hotbarSlot + 1 : -1;
     }
 
     /* Vanilla overrides */

--- a/src/main/java/tconstruct/tools/inventory/CraftingStationContainer.java
+++ b/src/main/java/tconstruct/tools/inventory/CraftingStationContainer.java
@@ -20,14 +20,8 @@ import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 
-import tconstruct.items.tools.Arrow;
-import tconstruct.items.tools.BowBase;
 import tconstruct.library.crafting.ModifyBuilder;
 import tconstruct.library.modifier.IModifyable;
-import tconstruct.library.tools.HarvestTool;
-import tconstruct.library.tools.Weapon;
-import tconstruct.library.weaponry.AmmoItem;
-import tconstruct.library.weaponry.ProjectileWeapon;
 import tconstruct.tools.TinkerTools;
 import tconstruct.tools.gui.ChestSlot;
 import tconstruct.tools.logic.CraftingStationLogic;
@@ -217,16 +211,10 @@ public class CraftingStationContainer extends Container {
             // Player inventory is always the fallback, so NEI can clear the grid.
             nothingDone &= moveToPlayerInventory(itemstack);
         } else if (index >= PLAYER_INVENTORY_FIRST_SLOT && index < PLAYER_INVENTORY_END_SLOT) {
-            // First to the crafting Matrix
-            nothingDone &= moveToCraftingGrid(itemstack);
-
-            // Then to any attached chest
+            // Move player stacks to the attached inventory.
             nothingDone &= this.moveToChest(itemstack);
         } else { // From the Attached Chests
-            // First to the crafting Matrix
-            nothingDone &= moveToCraftingGrid(itemstack);
-
-            // Then To Player Inv or Hotbar
+            // Move attached inventory stacks to the player inventory.
             nothingDone &= moveToPlayerInventory(itemstack);
         }
 
@@ -467,28 +455,6 @@ public class CraftingStationContainer extends Container {
         if (itemstack == null || itemstack.stackSize <= 0) return false;
 
         return !this.mergeItemStack(itemstack, PLAYER_INVENTORY_FIRST_SLOT, PLAYER_INVENTORY_END_SLOT, false);
-    }
-
-    protected boolean moveToCraftingGrid(ItemStack itemstack) {
-        if (itemstack == null || itemstack.stackSize <= 0) return false;
-
-        // We make a special check for tinker tools to move into the center of the crafting grid. This makes applying
-        // modifiers just a little bit more convenient.
-        Item item = itemstack.getItem();
-        if (item instanceof Arrow || item instanceof BowBase
-                || item instanceof HarvestTool
-                || item instanceof Weapon
-                || item instanceof AmmoItem
-                || item instanceof ProjectileWeapon) {
-
-            // We simply want to check if we are able to insert it into the center. If not, we continue as normal.
-            boolean wasAbleToInsertIntoCenter = this.mergeItemStack(itemstack, 5, 6, false);
-            if (wasAbleToInsertIntoCenter) {
-                return true;
-            }
-        }
-
-        return !this.mergeItemStack(itemstack, CRAFTING_GRID_FIRST_SLOT, CRAFTING_GRID_END_SLOT, true);
     }
 
     public boolean func_94530_a /* canMergeSlot */(ItemStack par1ItemStack, Slot par2Slot) {


### PR DESCRIPTION
## Summary

crafting station shift click now moves items directly between the player inventory and connected inventory instead of the crafting grid

also fixes tinkers tools in the first hotbar slot selecting slot 9 instead of slot 2


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
