### PR TITLE
Fix integer overflow on the durability path

### DIFF
--- a/src/main/java/tconstruct/library/crafting/ToolBuilder.java
+++ b/src/main/java/tconstruct/library/crafting/ToolBuilder.java
@@ -23,6 +23,11 @@ import tconstruct.library.util.IToolPart;
 
 public class ToolBuilder {
 
+    /** Narrows a durability figure to what the NBT holds, saturating rather than wrapping past Integer.MAX_VALUE. */
+    public static int clampDurability(long durability) {
+        return (int) Math.max(Integer.MIN_VALUE, Math.min(Integer.MAX_VALUE, durability));
+    }
+
     public static ToolBuilder instance = new ToolBuilder();
 
     public HashMap<String, ToolRecipe> recipeList = new HashMap<>();
@@ -170,7 +175,7 @@ public class ToolBuilder {
 
         if (extra != -1) extraMat = TConstructRegistry.getMaterial(extra);
 
-        int durability = headMat.durability();
+        long durability = headMat.durability();
         int heads = 1;
         int handles = 0;
         float modifier = 1f;
@@ -212,7 +217,10 @@ public class ToolBuilder {
             modifier /= handles;
         }
 
-        durability = (int) (durability / heads * (0.5 + heads * 0.5) * modifier * item.getDurabilityModifier());
+        // Summed in long: three endgame heads can exceed what an int holds, and a wrapped sum built tools
+        // with garbage durability. The product saturates at Integer.MAX_VALUE instead.
+        int totalDurability = clampDurability(
+                (long) (durability / heads * (0.5 + heads * 0.5) * modifier * item.getDurabilityModifier()));
         attack = attack / heads + item.getDamageVsEntity(null);
         if (attack % heads != 0) attack++;
 
@@ -236,8 +244,8 @@ public class ToolBuilder {
         }
 
         compound.getCompoundTag("InfiTool").setInteger("Damage", 0); // Damage is damage to the tool
-        compound.getCompoundTag("InfiTool").setInteger("TotalDurability", durability);
-        compound.getCompoundTag("InfiTool").setInteger("BaseDurability", durability);
+        compound.getCompoundTag("InfiTool").setInteger("TotalDurability", totalDurability);
+        compound.getCompoundTag("InfiTool").setInteger("BaseDurability", totalDurability);
         compound.getCompoundTag("InfiTool").setInteger("BonusDurability", 0); // Modifier
         compound.getCompoundTag("InfiTool").setFloat("ModDurability", 0f); // Modifier
         compound.getCompoundTag("InfiTool").setBoolean("Broken", false);

--- a/src/main/java/tconstruct/library/tools/AbilityHelper.java
+++ b/src/main/java/tconstruct/library/tools/AbilityHelper.java
@@ -376,7 +376,7 @@ public class AbilityHelper {
             if (damagedTool) return;
 
             int damage = tags.getCompoundTag("InfiTool").getInteger("Damage");
-            int damageTrue = damage + dam;
+            long damageTrue = (long) damage + dam; // a death penalty on a huge tool can push this past int
             int maxDamage = tags.getCompoundTag("InfiTool").getInteger("TotalDurability");
             if (damageTrue <= 0) {
                 tags.getCompoundTag("InfiTool").setInteger("Damage", 0);
@@ -384,7 +384,7 @@ public class AbilityHelper {
             } else if (damageTrue > maxDamage) {
                 breakTool(stack, tags, entity);
             } else {
-                tags.getCompoundTag("InfiTool").setInteger("Damage", damage + dam);
+                tags.getCompoundTag("InfiTool").setInteger("Damage", (int) damageTrue);
                 int toolDamage = (damage * 100 / maxDamage) + 1;
                 int stackDamage = stack.getItemDamage();
             }

--- a/src/main/java/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/tconstruct/library/tools/ToolCore.java
@@ -691,7 +691,7 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
             int energy = tags.getInteger("Energy");
             int max = getMaxEnergyStored(stack);
             if (energy > 0) {
-                int damage = ((max - energy) * 100) / max;
+                int damage = (int) (((long) max - energy) * 100 / max);
                 if (damage == 0 && max - energy > 0) damage = 1;
                 super.setDamage(stack, damage);
                 return damage;
@@ -700,7 +700,8 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, IEq
         int dur = tags.getCompoundTag("InfiTool").getInteger("Damage");
         int max = tags.getCompoundTag("InfiTool").getInteger("TotalDurability");
         int damage = 0;
-        if (max > 0) damage = (dur * 100) / max;
+        // long: a tool with more than ~21M durability wraps dur * 100 once it is worn enough
+        if (max > 0) damage = (int) ((long) dur * 100 / max);
 
         // rounding.
         if (damage == 0 && dur > 0) damage = 1;

--- a/src/main/java/tconstruct/library/weaponry/AmmoItem.java
+++ b/src/main/java/tconstruct/library/weaponry/AmmoItem.java
@@ -51,7 +51,7 @@ public abstract class AmmoItem extends ToolCore implements IBattlegearWeapon, IA
         if (!stack.hasTagCompound()) return toAdd;
         NBTTagCompound tags = stack.getTagCompound().getCompoundTag("InfiTool");
         int oldCount = tags.getInteger("Ammo");
-        int newCount = Math.min(oldCount + toAdd, getMaxAmmo(stack));
+        int newCount = (int) Math.min((long) oldCount + toAdd, getMaxAmmo(stack));
         setAmmo(newCount, stack);
         return toAdd - (newCount - oldCount);
     }

--- a/src/main/java/tconstruct/modifiers/tools/ModDurability.java
+++ b/src/main/java/tconstruct/modifiers/tools/ModDurability.java
@@ -3,6 +3,7 @@ package tconstruct.modifiers.tools;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.modifier.ItemModifier;
 import tconstruct.util.config.PHConstruct;
 
@@ -37,18 +38,18 @@ public class ModDurability extends ItemModifier {
         NBTTagCompound tags = tool.getTagCompound().getCompoundTag("InfiTool");
 
         int base = tags.getInteger("BaseDurability");
-        int bonus = tags.getInteger("BonusDurability");
-        float modDur = tags.getFloat("ModDurability");
-
-        bonus += durability;
-        modDur += modifier;
+        long bonus = (long) tags.getInteger("BonusDurability") + durability;
+        float modDur = tags.getFloat("ModDurability") + modifier;
         tags.setBoolean("Broken", false);
 
-        int total = (int) ((base + bonus) * (modDur + 1f));
+        // A tool made of an endgame material can already sit at Integer.MAX_VALUE. Adding to that in int
+        // wrapped negative, and the guard below then handed the player a tool with one point of durability.
+        // The float product is unchanged so every tool that never overflowed keeps its exact figure.
+        long total = (long) ((float) (base + bonus) * (modDur + 1f));
         if (total <= 0) total = 1;
 
-        tags.setInteger("TotalDurability", total);
-        tags.setInteger("BonusDurability", bonus);
+        tags.setInteger("TotalDurability", ToolBuilder.clampDurability(total));
+        tags.setInteger("BonusDurability", ToolBuilder.clampDurability(bonus));
         tags.setFloat("ModDurability", modDur);
 
         if (PHConstruct.miningLevelIncrease) {

--- a/src/main/java/tconstruct/weaponry/WeaponryActiveToolMod.java
+++ b/src/main/java/tconstruct/weaponry/WeaponryActiveToolMod.java
@@ -19,7 +19,7 @@ public class WeaponryActiveToolMod extends ActiveToolMod {
                 int rem = ammo.consumeAmmo(1, stack);
                 return rem > 0;
             } else if (ammo.getAmmoCount(stack) > 0) {
-                int d = tags.getInteger("Damage") + damage;
+                long d = (long) tags.getInteger("Damage") + damage;
                 int max = tags.getInteger("TotalDurability");
                 if (d > max) {
                     tags.setInteger("Damage", 0);


### PR DESCRIPTION

Based on `master` at **1.14.106-GTNH + #309 + #320** (`74e91553`). Three commits, six files, **+28/−18**: seven `int` expressions on the
durability path do their arithmetic in `long` and narrow it with saturation. No config option, no new NBT tag, no lang key, no asset, no
recipe; the one new public symbol is `ToolBuilder.clampDurability(long)`.

## What this fixes

A tool built from an endgame GTNH material is created at `TotalDurability = 2147483647`. Applying a Diamond to
it hands back a tool at **`1/1`** that breaks on the first block. `ModDurability` adds the bonus to the base in
`int`, the sum wraps negative, and the guard meant to catch zero-durability tools clamps the wreckage to 1. Six
more expressions on the same path have the same shape.

This is not a backport of anything — it is a bug that only GTNH can reach.

## The bug, exactly

Stock `ModDurability.modify`:

```java
int base  = tags.getInteger("BaseDurability");   // 2147483647 on a Shirabon hammer
int bonus = tags.getInteger("BonusDurability");
...
bonus += durability;                             // Diamond: +500
int total = (int) ((base + bonus) * (modDur + 1f));
if (total <= 0) total = 1;                       // guard for zero-durability tools
```

`base + bonus` is an `int` addition. `2147483647 + 500` wraps to `-2147483149`, the float product stays
negative, the cast keeps it negative, and the guard writes `TotalDurability = 1`. Reproduced in-game on
2026-08-19 at a Tool Forge: the hammer goes from `- 2147483647/2147483647` to `Durability: 1/1` the moment the
Diamond lands in a slot. (The leading `-` is the stock bullet prefix, not a minus sign:
`ToolStationGuiHelper.drawDurability` splits the stat onto two lines whenever `TotalDurability >= 10000`. The
tool is undamaged at 2,147,483,647. My screenshots predate #309, which put grouping commas and spaces on that
line, so the same reading prints as `- 2,147,483,647 / 2,147,483,647` on current `master`.)

### Why GTNH reaches this and upstream never did

Nothing in stock Tinkers' has a material anywhere near the ceiling. GTNH gets there through the multiplier
chain, not through one big number. `ToolBuilder.buildTool` computes

```
(sum of head-type parts / heads) * (0.5 + heads * 0.5) * handleModifier * item.getDurabilityModifier()
```

and that product already saturates on its own `(int)` cast. For an all-Shirabon hammer that is three head-type
parts (head + two large plates), `heads = 3`, so `(0.5 + 3*0.5) = 2.0`, `handleModifier` = the rod's 25.5×
(read from the tooltip in-game on 2026-08-30) and `item.getDurabilityModifier()` = **4.5** (`Hammer.java`).
The per-part figure is pinned by measurement rather than assumed: swapping in a titanium rod (3.5×) rebuilt the
same hammer to **371,589,120**, which fixes `perPart × 2 × 4.5` at 106,168,320, i.e. an effective **11,796,480**
per part. That is GoodGenerator's registered Shirabon durability of 15,728,640 (`Werkstoff.setDurOverride`,
read with `javap` from the shipped jar) scaled by GTNH's IguanaTweaks `durabilityPercentage = 75`.

So `11,796,480 × 2.0 × 25.5 × 4.5 = 2,707,292,160` — 26% over the ceiling, so `BaseDurability` is written as
exactly `Integer.MAX_VALUE`. Every tool that gets there is one Diamond away from being destroyed.

### Why not just widen the NBT

`TotalDurability` is an `int` in NBT, read by this mod, by TGregworks and by IguanaTweaks; vanilla item damage
is an `int` too. Changing the type breaks saves and third-party mods for no gameplay gain — `Integer.MAX_VALUE`
is about 2.1 billion uses, roughly three and a half years of nonstop mining. The bug is *wrapping past* the
ceiling, not the ceiling itself.

Worth saying once, because it comes up: a tool at `2147483647` is **not** unbreakable. Unbreakable is
Reinforced ×10 (100% chance to skip durability use). A huge `TotalDurability` is just a huge number that still
counts down — and once the overflow drops it to 1, the tool genuinely breaks.

## Player-visible behaviour

| Situation | Before | After | How you reach it |
|---|---|---|---|
| Diamond (or any additive durability modifier) on a tool whose base + bonus exceeds `Integer.MAX_VALUE` | tool comes out `1/1`, breaks on first use | stays `2147483647` | any tool with `BaseDurability` ≥ 2,147,483,148; an all-Shirabon hammer is already there |
| A tool already ruined to `1/1`, put back in a station with an **Emerald** | recomputed from the same wrapped sum, stays 1 | recomputed from the intact `BaseDurability` → `2147483647` | a station visit, not a retroactive heal — see the disclosure below |
| Tool built from 2–4 head-type parts whose durabilities sum past 2³¹ | wrapped: 3 × MAX gives 1,431,655,762, 2 × MAX gives −1 | `2147483647` | needs a TGregworks per-material multiplier; no shipped material is that large today |
| Durability bar / F3+H percent once `Damage` passes 21,474,836 | garbage: reads 1% used on a half-worn MAX tool, or the bar disappears when the wrapped percent comes out negative | exact percentage | **one death** with the default death penalty on a MAX tool |
| Flux bar with more than 21,474,836 RF missing | same garbage | exact percentage | same expression; I did **not** check that any GTNH Flux tool holds that much |
| Ammo restock or pickup-stacking on MAX-scale ammo | count wraps negative, the stack can no longer be fired or thrown | caps at max ammo | Shirabon-headed ammo plus metal blocks in the slots; reachability caveat below |
| Death penalty pushing `Damage + penalty` past 2³¹ | wrapped sum read as healing — the tool is silently fully repaired | the tool breaks, which is what the code intends | ~10 prior death penalties on a MAX tool |
| A javelin in that same case | its reset-instead-of-break guard is skipped, and the wrap in `AbilityHelper` repairs it instead | its own guard fires and `Damage` resets to 0 | same |

For every tool whose sums never overflowed, every NBT value written and every `getDamage()` return is
bit-identical to the old code (see Verification).

## How the fix works

One helper on `ToolBuilder`:

```java
/** Narrows a durability figure to what the NBT holds, saturating rather than wrapping past Integer.MAX_VALUE. */
public static int clampDurability(long durability) {
    return (int) Math.max(Integer.MIN_VALUE, Math.min(Integer.MAX_VALUE, durability));
}
```

Then, at each site: widen the operands to `long`, do the sum, narrow with `clampDurability` (or a plain `(int)`
where the value is provably in range).

Three deliberate non-changes, because they are what keeps this a bugfix and not a rebalance:

- **The float product in `ModDurability` stays a float.** `(float)(base + bonus) * (modDur + 1f)` already loses
  precision above 2²⁴, so on a 100M-durability tool the `+500` is partly rounded away. That rounding is
  preserved exactly. "Fixing" it with a double would change the durability number of every large tool in every
  existing save.
- **The `if (total <= 0) total = 1` guard is untouched**, and `clampDurability` saturates at `Integer.MIN_VALUE`
  at the bottom rather than at 1, so the guard still decides that case — and it fires in exactly the same
  situations as before (proven below over every float bit pattern).
- **The truncating `durability / heads` division stays truncating.** Widening the accumulator turns it from
  `int / int` into `long / int`; both truncate toward zero, so every existing tool keeps its exact figure
  (checked over all 2³² sums for 2 and 3 heads). Doing that division in `double` instead — the obvious "while
  you are in there" improvement — would nudge the durability of every multi-head tool already in a save, so I
  did not.

## Changes, site by site

| File · method | Stock expression | Symptom | Fix |
|---|---|---|---|
| `modifiers/tools/ModDurability.java` · `modify` | `int total = (int) ((base + bonus) * (modDur + 1f));` | **destroys the tool** — Diamond on a MAX tool → `1/1` | `long bonus` / `long total`, `clampDurability` on both NBT writes |
| `library/crafting/ToolBuilder.java` · `buildTool` | `int durability = headMat.durability();` then `durability += …` once per head-type part | **destroys the tool** — a wrapped sum builds a tool with negative durability | `long` accumulator, `clampDurability` on the product |
| `library/tools/ToolCore.java` · `getDamage` (durability) | `damage = (dur * 100) / max;` | wrong bar and percent once `Damage` > 21,474,836 | `(int) ((long) dur * 100 / max)` |
| `library/tools/ToolCore.java` · `getDamage` (Flux) | `int damage = ((max - energy) * 100) / max;` | same shape for more than 21,474,836 RF missing | `(int) (((long) max - energy) * 100 / max)` |
| `library/tools/AbilityHelper.java` · `damageTool` | `int damageTrue = damage + dam;` | a wrapped sum lands in the `<= 0` branch — a **free full repair** instead of breaking | `long damageTrue`, same three branches, exact `(int)` write |
| `library/weaponry/AmmoItem.java` · `addAmmo` | `Math.min(oldCount + toAdd, getMaxAmmo(stack))` | **destroys the ammo** — count wraps negative, the stack can no longer be fired | `(int) Math.min((long) oldCount + toAdd, getMaxAmmo(stack))` |
| `weaponry/WeaponryActiveToolMod.java` · `damageTool` | `int d = tags.getInteger("Damage") + damage;` | javelin's reset-instead-of-break guard is skipped | `long d` |

<details>
<summary>Why each of the read-side sites is reachable at all</summary>

- **`ToolCore.getDamage`** — `dur * 100` wraps once `InfiTool.Damage` passes 21,474,836. That does not need
  grinding: GTNH ships *Tools lose 10% durability on death* enabled (`PHConstruct.deathPenality`, default
  `true`, and `true` in my test instance's `TinkersConstruct.cfg`), and `TinkerToolEvents.damageToolsOnDeath`
  deals `TotalDurability / 20` on Normal or `/ 10` on Hard in a single hit — 107,374,182 or 214,748,364 points
  on a MAX tool. **One death** puts a Shirabon tool past the wrap point. From then on the percent is garbage in
  one of two ways: a negative percent makes `showDurabilityBar` (which requires `getDamage > 0`) hide the bar
  entirely, and a wrapped-to-small percent reads as 1% used on a half-worn tool. The wrong number is copied
  into the vanilla item damage by `super.setDamage`, so the hotbar bar, F3+H and anything reading
  `isItemDamaged` see it. Aside: the fork's creative Hammer and Frying Pan sit at
  `Integer.MAX_VALUE / 100 = 21,474,836`, whose ×100 product is 2,147,483,600 — 47 below the ceiling, which
  looks deliberate. One Diamond raises them to 21,475,336 and the product to 2,147,533,600, past it. The margin
  is that thin.
- **`AbilityHelper.damageTool`** — `dam` is normally 1, but the same death penalty passes `TotalDurability / 10`
  on Hard. With `Damage` already near MAX the sum wraps negative and the `<= 0` branch writes
  `Damage = 0, Broken = false`. Needs about ten prior death penalties on a MAX tool; theoretical, but the
  outcome is the wrong one in the wrong direction.
- **`AmmoItem.addAmmo`** — `ModAmmoRestock` computes the increase in float and its `(int)` cast *saturates* to
  `Integer.MAX_VALUE` for MAX-scale ammo, so the very next `oldCount + toAdd` wraps. Concretely, a
  Shirabon-head arrow stack (`getMaxAmmo` = `ceil(TotalDurability * 0.1)` = 214,748,365) that has been partly
  fired: `oldCount` 214,748,364, `toAdd` saturated to 2,147,483,647 → old `newCount = -1,932,735,285`, and
  `getAmmoCount(stack) > 0` is then false everywhere, so the stack can no longer be fired or thrown; new
  `newCount = 214,748,365`. **Reachability caveat:** this needs a material worth ~18 per unit in the restock
  slots (metal *blocks*) — with ingots at 2 each, five slots cannot push `toAdd` high enough. Whether GregTech
  registers `block<Material>` pattern materials at value 18 the way `TinkerTools` does is outside this repo and
  I did not audit it. If it does not, this site is unreachable in play and the fix is pure hardening.
- **`ToolBuilder.buildTool`** — with the materials the pack ships today the head sum does not wrap: the largest
  per-part durability that actually has a Tinkers part is Shirabon at 11,796,480, and four of those still sum to
  47M, well under `Integer.MAX_VALUE`. (GregTech's table has bigger entries, Magmatter at 167,772,160 among them,
  but none of them is enabled as a Tinkers material: `TGregworks.cfg` has `B:Magmatter=false`, and the next
  enabled parts below Shirabon are Ichorium 637,500, Neutronium 491,520 and Infinity Catalyst 375,000, read from
  the GT jar and checked against the plate tooltips in-game.) It becomes reachable through configuration:
  TGregworks' `materials.durability` per-material multipliers document a range of 0.0–10000.0, and its own
  float→int cast saturates, so a single config line can put a part at MAX and make every 2+-head tool build
  wrong. Fixed because it is the same expression and costs one keyword.

</details>

## Behaviour differences from stock

The table above lists what changes. These are the parts of it that take something away, need a caveat, or are
not obvious from the diff — a maintainer should not discover any of them after merging.

- **[takes something away]** A death penalty on a tool whose `Damage + penalty` exceeds 2³¹ now **breaks the
  tool** instead of silently fully repairing it. The old behaviour was an accident of the wrap landing in the
  "heal" branch; the new behaviour is what the surrounding code says should happen. If anyone is relying on the
  accident, this is where it goes away.
- **[opposite direction, on purpose]** Javelins do *not* break in that case. `WeaponryActiveToolMod.damageTool`
  has its own guard that resets a javelin's `Damage` to 0 instead of breaking it; the wrapped `int` sum skipped
  that guard, so control fell through to `AbilityHelper` and the javelin was fully repaired by the wrap there
  instead. With both sums in `long` the javelin's own guard fires and the javelin is reset, which is what that
  code says should happen. (Between my second and third commit the javelin broke instead — that intermediate
  state is not what this PR merges.)
- **[beneficial, but no migration]** A tool already ruined to `1/1` keeps its intact `BaseDurability`, so
  putting it back in a station and applying an **Emerald** restores 2,147,483,647 (Diamond cannot be re-applied
  to the same tool — `ModDurability`'s key check — so Emerald is the route). Nothing scans saves for tools the
  old bug already ruined, and repairing one with materials does not help: `ModRepair` finishes with a
  `damageTool(tool, 0, null, true)` call that re-breaks any tool whose `Damage` exceeds its collapsed
  `TotalDurability`. A station visit is the one route back. I considered a world-load migration and a hard
  clamp of `getDamage` to 100 and did neither, because both touch tools this bug never affected — happy to add
  one if you would rather ship a migration.
- **[write path, not just display]** `getDamage` is the vanilla item-damage bridge, not only a bar:
  `ToolCore.setDamage` turns an incoming vanilla request into raw points as `requested - stack.getItemDamage()`,
  and `getDamage` is what wrote that stored percent. So on a tool past the wrap point, an external mod calling
  `setItemDamage`/`damageItem` now gets the correct raw delta instead of one computed against a garbage
  baseline (on a half-worn MAX tool the baseline moves from 1 to 49). Only tools in the overflow regime are
  affected; for everything else `getDamage` is bit-identical.
- **[return value, not just the stored count]** `addAmmo` reports how much it could *not* add
  (`toAdd - (newCount - oldCount)`), and callers use that to decide what to keep. In the wrapping case that
  used to be 0 ("all consumed") while the stack was destroyed; it now reports the real remainder, so
  `ModAmmoRestock` and the pickup path consume the right amount of input.
- **[not verified: Flux reachability]** I fixed the identical expression on the Flux branch because it is the
  same shape and one keyword, but I did **not** verify that any Flux-capable Tinkers tool in GTNH actually
  reaches 21,474,836 RF of missing charge. The trigger may not exist in the pack today.
- **[out of repo, and this PR changes who meets it]** IguanaTweaksTConstruct's part replacement still collapses
  a MAX-scale tool to `TotalDurability = 1`; it carries its own copy of the expression and can only be fixed
  there. This PR does not cause that and cannot fix it, but it does change who runs into it: today the tool is
  already ruined by the first Diamond, so almost nobody reaches a part swap with one. After this merge those
  tools survive and stay in circulation, and a part swap becomes the remaining way to collapse one. Companion
  PR described at the end.
- **[none]** For every tool whose sums never overflowed: every NBT value (`TotalDurability`, `BaseDurability`,
  `BonusDurability`, `ModDurability`, `Damage`, `Ammo`) and every `getDamage()` return is bit-identical to the
  old code.

## Verification

Honest split: the arithmetic is proven by executable ports of the old and new expressions — exhaustively where
the domain allows and over dense grids plus tens of millions of random draws where it does not; the headline
bug is confirmed in-game; several of the rarer sites are proven but never staged in a world.

### In-game

Tested at a Tool Forge in a throwaway copy of GTNH 2.9.0-beta-2. Every in-game result below was taken on a jar
cut on an older `master`: 1.14.98-GTNH for the repro, 1.14.104-GTNH for the later confirmations. The three
commits are byte-for-byte the same on the head this PR pushes (`git range-diff` against the older cut is clean),
but that head has been built and fingerprinted on `74e91553`, not yet played.

- **Bug reproduced 2026-08-19** with the stock arithmetic: a Shirabon hammer at `- 2147483647/2147483647` with
  40 free modifier slots and no modifiers; drop a Diamond in a slot and the preview reads `Durability: 1/1`
  with `- Diamond` in the modifier list.
- **Fix confirmed 2026-08-30** with a jar carrying this branch: a Shirabon hammer at `- 2147483647/2147483647`
  plus a Diamond previews `- 2147483647/2147483647` and lists the Diamond. It is a **different hammer** from
  the 2026-08-19 shot (this one already carries a Redstone modifier and creative modifier slots from other
  testing); the arithmetic under test — `BaseDurability` at MAX plus a +500 additive modifier — is identical.
- **Confirmed again 2026-09-02**, again with a jar carrying this branch, on a fresh all-Shirabon hammer with 64
  free slots and no other modifiers: with the Diamond applied it reads `- 2147483647/2147483647`,
  `Modifiers remaining: 63`, `- Diamond` (`2026-09-02-ichorium-round/73-diamond-applied-still-max.png` below).
- The Emerald recovery of an already-ruined `1/1` tool was checked in the same 2026-08-19 session and did
  restore 2,147,483,647; I have no screenshot of it.
- **All seven screenshots come from a development instance** that also carries my Tool Station GUI work (a
  separate PR) and the modifier toggle from another — hence the pentagon layout, the two side panels and the
  `Tiers: fill all` button. None of that is part of this PR and none of it touches the durability path; the
  durability numbers are the point, not the frame.
- **`./gradlew build` passes** on the standalone branch against `74e91553` — `spotlessCheck`, `checkstyleMain`,
  `test`, `jar`, `reobfJar` and `apiJar` all green; artifact `TConstruct-1.14.106-GTNH-git.5+c38ecf86a3.jar`.
- **The fix survives reobfuscation**, checked in that release jar rather than in the source: `ModDurability`
  carries `i2l` x3, `ladd` x2, `l2f` and `f2l`, and `ToolBuilder.clampDurability(long)` is present as a public
  member. The widening is not folded away by the compiler. (That jar also carries #324's
  `ToolCore.getAdjacentHotbarSlot`, which is how I know it really is built on current `master`.)
- The jar that produced the in-game evidence carries all four of my branches and was cut on an older `master` — I
  have not built and *played* a jar from this branch standing alone, and nothing has been played on a build cut on
  `74e91553` yet. CI on this PR is the authoritative build.

**To check it yourself without endgame materials:** any tool whose `InfiTool.BaseDurability` is above
2,147,483,147 reproduces it. Set that tag on any tool (NBT edit or a `/give` with the tag), put it in a station
with a Diamond and a free modifier slot: the preview reads `Durability: 1 / 1` on `master` and
`- 2,147,483,647 / 2,147,483,647` with this branch. 2,147,483,147 + 500 is exactly `Integer.MAX_VALUE` and is the
last non-overflowing value;
2,147,483,148 is the first that collapses.

<details>
<summary>Equivalence proofs (executable; exhaustive where the domain allows)</summary>

I ported the old and the new expression of each site to plain Java and ran them against each other.
**Exhaustive** marks the rows that cover every value in the domain; the rest are dense structured grids crossed
with the real parameter ranges, plus tens of millions of random draws.

| Proof | Cases | Result |
|---|---|---|
| `(float) i` vs `(float)(long) i` | **exhaustive**: all 2³² ints | bit-identical |
| `(int) f` vs `clampDurability((long) f)` | **exhaustive**: all 2³² float patterns, incl. NaN/Inf/subnormals | identical |
| The `total <= 0 → 1` guard fires in the same cases | **exhaustive**: all 2³² float patterns | identical |
| `ModDurability`, structured grid (17,225 base values — dense near 0, near every power of two, near 2²⁴ and near MAX — crossed with existing and added bonus and modifier over their real ranges) | 9,916,740 non-overflow | 0 differences — including 27,228 cases where the old float rounding already displaced the bonus, which the new code reproduces bit-for-bit |
| `ModDurability`, random base uniform over 0..MAX | 29,999,991 non-overflow | 0 differences |
| `ModDurability`, negative/corrupt bases incl. `Integer.MIN_VALUE` | 4,032 | 0 differences |
| `ToolBuilder.buildTool`, grid + random, 1–4 heads, real handle and item modifiers | 167,028,183 + 17,788,464 non-overflow | 0 differences; overflow cases give MAX or the mathematically exact value, never a negative |
| `ToolCore.getDamage`, durability branch, two independent sweeps | ~296M and ~300M | 0 differences; overflow now yields the exact 0–100 percentage |
| `ToolCore.getDamage`, Flux branch | exhaustive for `max <= 3000`, plus 2²⁶ random | 0 differences; 158 `EnergyMax == 0` cases throw in both old and new |
| `AbilityHelper.damageTool`, grid + 2²⁶ random | 117,168,303 non-overflow | 0 differences in branch taken or value written; overflow now breaks the tool instead of healing it |
| `AmmoItem.addAmmo`, grid + 2²⁶ random | 50,701,652 non-overflow | 0 differences; overflow caps at max ammo |

Bug repro inside the harness, for the record:

```
Shirabon + Diamond    old = 1              new = 2147483647
  … then + Emerald    old = 1              new = 2147483647
Shirabon + Emerald    old = 2147483647     new = 2147483647   (unchanged: Emerald's float multiply already saturated)
MAX/100 + Diamond     old = 21475336       new = 21475336     (unchanged)
3 × MAX heads         old = 1431655762     new = 2147483647
```

Boundary behaviour is exact, not approximate: `base = 2147483147` plus 500 is exactly MAX and is a non-overflow
case, identical old and new; `base = 2147483148` is the first value that used to collapse to 1.

**Bytecode.** `javap` on the compiled classes, old expression vs new: the only changed opcodes are the widening
and narrowing conversions (`i2l`/`ladd`/`l2f`/`f2l`/`lmul`/`ldiv`) plus the call to `clampDurability`. The
control flow of every changed method is structurally identical — same branches, same guards, same NBT keys
written in the same order, no new throw sites.

</details>

<details>
<summary>Adjacent problems I found and deliberately did not touch</summary>

Listing these so nobody has to re-find them.

- `ToolBuilder.buildTool` sums `attack` with the same `+=` pattern on the lines next to the durability sums
  (`ToolBuilder.java:182/192/203`), and I left it an `int`. Attack values are small — TGregworks sets attack
  from tool quality, so the largest shipped value is two digits — and widening it would change a second stat
  for no reachable bug. Say the word and I will do it in the same shape.
- `AbilityHelper.damageTool` has two dead locals (`toolDamage`, `stackDamage`) that are computed and never
  read. The multiply in `toolDamage` wraps under the same condition as `ToolCore.getDamage`, but nothing
  consumes it, and it cannot divide by zero in that branch. Left in to keep the diff to the bug — happy to
  delete them here if you prefer.
- `AmmoItem.addAmmo`'s return expression `toAdd - (newCount - oldCount)` can go negative, but only when `Ammo`
  already exceeds `getMaxAmmo` — i.e. NBT corrupted by something else. Pre-existing, unchanged.
- The Flux branch of `ToolCore.getDamage` throws `ArithmeticException` when `EnergyMax` is 0 and energy is
  positive. It did before this PR and it does after; exception parity was checked rather than "fixed".
- `AbilityHelper.damageTool`'s Reinforced loop iterates once per point of damage, so a death penalty on a
  MAX-durability tool with Unbreaking spins 100M+ RNG calls in a single tick (a multi-second server hitch).
  That is not an overflow and is not touched here — flagging it as worth its own issue.
- `TotalDurability` stays an `int` in NBT, on purpose, for the reasons above.

</details>

<details>
<summary>Not reproduced in a world</summary>

Proven in the harness and by reading the call sites, but never staged in-game, and I would rather say so than
imply otherwise:

- the multi-head build wrap (needs a TGregworks config multiplier to put a part at MAX);
- the death-penalty overflow (needs `Damage` near 2 billion, i.e. ~10 prior death penalties on a MAX tool or an
  NBT edit) and the javelin case with it;
- the ammo restock overflow (needs MAX-scale ammo plus metal blocks in the station slots, subject to the
  reachability caveat in the site notes);
- the durability and Flux bar percentages. One death with the default death penalty is enough to set the
  durability one up on a MAX tool — it is a cheap test and I simply have not staged it.

</details>

## Companion PR in IguanaTweaksTConstruct

For the avoidance of doubt in the other direction: IguanaTweaks replaces several Tinkers' modifier classes at
runtime, but `ModDurability` is not one of them — its modifier classes are `ModBonusMiningLevel`, `ModCritical`,
`ModMiningLevelBoost`, `ModShoddy`, `ModXpAwareRedstone`, `ModFluxExpensive` and `ModLimitedToolRepair` (read
from the shipped 2.7.10 jar). The class fixed here is the class that runs in a real GTNH instance.

What IguanaTweaks *does* own is a second copy of the same expression:
`iguanaman.iguanatweakstconstruct.replacing.ReplacementLogic.exchangeToolPart` recomputes durability after a
part swap as

```java
int total = Math.max((int) ((base + bonus) * (modDur + 1f)), 1);
```

Same `int` addition, same wrap, same clamp to 1 — confirmed by `javap` on the shipped 2.7.10 jar, and it cannot
be fixed from this repo. I have the one-line fix on a branch there (parity checked over 27.2M cases) and will
open that PR after this one, linking back here.

One honest caveat on that companion PR, which is also why it is not bundled into this one: **I have not
reproduced the IguanaTweaks failure in a world, and with the pack's stock material values it cannot be reached.**
From the tool station it needs the *rebuilt* base to stay within 500 of the ceiling. The all-Shirabon product
overshoots `Integer.MAX_VALUE` by about 1.26×, so a swapped-in rod has to keep a multiplier of at least 20.23×
against Shirabon's 25.5×, or a swapped-in head/plate has to have a per-part durability of at least 4,478,715;
same-material swaps are refused by `ModPartReplacement.canModify`. No enabled material gets near that: the largest
Tinkers parts after Shirabon itself are Ichorium 637,500, Neutronium 491,520 and Infinity Catalyst 375,000 (read
from the GT jar, scaled by IguanaTweaks' `durabilityPercentage = 75`, checked against the plate tooltips in-game),
and everything bigger in GregTech's table (Magmatter 167,772,160, Stellar 100,000,000 and the rest) has no Tinkers
part at all (`TGregworks.cfg` `B:Magmatter=false` and so on); no enabled rod comes close to 20× either (titanium
is 3.5×). Everything I could stage on that hammer came out correct and far below the window: two rod swaps that
the formula reproduces to the digit, titanium ×3.5 → 371,589,120 and a ×0.6 rod → 63,700,992
(`2026-08-30-part-swap-rod-no-diamond-63700992.png`), a third rod reading of 1,804,867,200 that sits 5,760 above
×17.0 and that I could not reconstruct (harmless either way), and two plate swaps: a Neutronium Large Plate with no
Diamond → 1,842,462,720 on 2026-08-31 (`2026-08-31-checklist-round/13-neutronium-plate-swap-1842462720.png`) and
an Ichorium Large Plate with the Diamond already on the hammer → 1,853,630,720 on 2026-09-02
(`2026-09-02-ichorium-round/75-after-swap-1853630720.png`), both exactly what the formula predicts, the Ichorium
one including the Diamond's +500 through the same `(float)` cast. I have not staged a head swap; a head is
averaged with the plates in the same sum, so it would not change the threshold. The one way to see the
IguanaTweaks failure is a config edit: a `materials.durability` multiplier in `TGregworks.cfg` (documented range
0.0–10000.0) on any enabled head material puts the next swap's rebuilt base at the ceiling. That PR will describe
that repro and not claim a play path; it stands on the identical expression, the in-game repro of this one and
the 27.2 M-case parity check.

## Screenshots

All from the test instance described under *In-game*, so the pentagon screen and the `Tiers` button in them belong
to my other PRs, not to this one. They also predate #309, so the durability lines in them print without grouping
commas.

Before: a Shirabon hammer at `- 2147483647/2147483647`, no modifiers, 40 free modifier slots.

![](https://raw.githubusercontent.com/Aintripin/TinkersConstruct/pr-assets/pr1/1-before-shirabon-hammer-max.png)

Before: the same hammer with one Diamond in a slot — the preview collapses to `Durability: 1/1`.

![](https://raw.githubusercontent.com/Aintripin/TinkersConstruct/pr-assets/pr1/2-before-diamond-collapses-to-1.png)

After, with this branch: a Shirabon hammer plus a Diamond keeps `- 2147483647/2147483647` and lists the Diamond. A different hammer from the two shots above (it already carries Redstone from other testing).

![](https://raw.githubusercontent.com/Aintripin/TinkersConstruct/pr-assets/pr1/3-after-diamond-keeps-max.png)

A part swap on a Shirabon hammer with no Diamond applied: rebuilt durability 63,700,992, correct — the IguanaTweaks path only misbehaves once the rebuilt base lands within 500 of the ceiling.

![](https://raw.githubusercontent.com/Aintripin/TinkersConstruct/pr-assets/pr1/4-part-swap-rod-63700992.png)

After, with this branch, 2026-09-02: a fresh all-Shirabon hammer with 64 free slots and no other modifiers takes a Diamond and stays at `- 2147483647/2147483647`, 63 slots left.

![](https://raw.githubusercontent.com/Aintripin/TinkersConstruct/pr-assets/pr1/5-after-fresh-hammer-diamond-still-max.png)

A Neutronium Large Plate (491,520 per part) swapped into the all-Shirabon hammer, no Diamond: rebuilt to 1,842,462,720, exactly what the durability formula predicts.

![](https://raw.githubusercontent.com/Aintripin/TinkersConstruct/pr-assets/pr1/6-neutronium-plate-swap-1842462720.png)

The 2026-09-02 hammer after an Ichorium Large Plate (637,500 per part) swap with the Diamond already on it: 1,853,630,720, exact including the Diamond's +500. The IguanaTweaks path is correct until the rebuilt base lands within 500 of the ceiling, which no enabled material reaches.

![](https://raw.githubusercontent.com/Aintripin/TinkersConstruct/pr-assets/pr1/7-ichorium-plate-swap-1853630720.png)

## Merge notes

- **This one is independent: merge it whenever, in any order.** Three unrelated PRs follow from me — expander
  modifiers, tool station / forge screen, multi-modifier crafts
  (#326, #327, #328) — and none of them touches any of these six files.
- Cut on current `master` (`74e91553`, i.e. 1.14.106-GTNH plus #309 and #320) and compiled there.
- Only two of the six files have moved upstream at all since this branch was first written (1.14.98-GTNH), and
  neither collides. In `AbilityHelper`,
  #315 guards the *call site* of `damageTool` with a block-hardness check (line 57) while this PR widens the
  arithmetic *inside* the method (lines 379 and 387). In `ToolCore`, every upstream hunk sits above my two at 694
  and 703: #309's static import and tooltip lines (3, 292, 356), #321's render-key block (580–600) and #324's
  `onItemRightClick` change plus its new `getAdjacentHotbarSlot` helper (619 and 644). The other four files are
  untouched upstream.
- Three commits (`Keep tool durability from wrapping past Integer.MAX_VALUE`, `Do the durability bar, damage,
  and ammo sums in long as well`, `Sum javelin damage in long too`). Squash if you prefer; the split is only
  there to keep the root cause separate from the sweep.
- No config option on purpose — a toggle here would mean shipping the wrap as a supported option, and there is
  no setting of it a player would want: the old behaviour is a destroyed tool, a garbage durability bar or a
  free repair. The saturating result is what the surrounding code already intends in every case.
- Save-compatible in both directions: the fix changes which number gets written, never the shape of the data.
