### PR TITLE
Bugfix blocking damage battlesign

### DIFF
--- a/src/main/java/tconstruct/modifiers/tools/ModAttack.java
+++ b/src/main/java/tconstruct/modifiers/tools/ModAttack.java
@@ -91,12 +91,11 @@ public class ModAttack extends ItemModTypeFilter {
 
         if (tags.hasKey(key)) {
             int[] keyPair = tags.getIntArray(key);
-            int overThreshold = increase / threshold;
 
             int leftToBoost = threshold - (keyPair[0] % threshold);
             if (increase >= leftToBoost) {
                 int attack = tags.getInteger("Attack");
-                attack += (overThreshold > 1) ? overThreshold : 1;
+                attack += 1 + (increase - leftToBoost) / threshold;
                 tags.setInteger("Attack", attack);
             }
 
@@ -118,14 +117,13 @@ public class ModAttack extends ItemModTypeFilter {
             int modifiers = tags.getInteger("Modifiers");
             modifiers -= 1;
             tags.setInteger("Modifiers", modifiers);
-            int overThreshold = increase / threshold;
             String modName = "\u00a7f" + guiType + " (" + increase + "/" + max + ")";
             int tooltipIndex = addToolTip(tool, tooltipName, modName);
             int[] keyPair = new int[] { increase, max, tooltipIndex };
             tags.setIntArray(key, keyPair);
 
             int attack = tags.getInteger("Attack");
-            attack += (overThreshold >= 1) ? overThreshold : 0;
+            attack += 1 + (increase / threshold);
             tags.setInteger("Attack", attack);
         }
     }

--- a/src/main/java/tconstruct/modifiers/tools/ModAttack.java
+++ b/src/main/java/tconstruct/modifiers/tools/ModAttack.java
@@ -123,7 +123,7 @@ public class ModAttack extends ItemModTypeFilter {
             tags.setIntArray(key, keyPair);
 
             int attack = tags.getInteger("Attack");
-            attack += 1 + (increase / threshold);
+            attack += 1 + increase / threshold;
             tags.setInteger("Attack", attack);
         }
     }

--- a/src/main/java/tconstruct/world/TinkerWorldEvents.java
+++ b/src/main/java/tconstruct/world/TinkerWorldEvents.java
@@ -94,7 +94,7 @@ public class TinkerWorldEvents {
                 if (item == TinkerTools.cutlass) {
                     player.addPotionEffect(new PotionEffect(Potion.moveSpeed.id, 3 * 20, 1));
                 } else if (item == TinkerTools.battlesign) {
-                    event.ammount *= 1.5; // Puts battlesign blocking at 3/4 instead of 1/2
+                    event.ammount *= 0.25; // Puts battlesign blocking at 3/4 instead of 1/2
                 }
             }
         } else if (reciever instanceof EntityCreeper) {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

My attention was drawn to a value that differed from the one in the comment. Instead of blocking damage, the used combat table was actually adding another 50% on top-even though the intended block amount was 50% or 75%. I set the value to match what was specified in the comment.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
