### PR TITLE
add config option for classic crafting station layout

### DIFF
--- a/src/main/java/tconstruct/tools/gui/CraftingStationGui.java
+++ b/src/main/java/tconstruct/tools/gui/CraftingStationGui.java
@@ -30,6 +30,7 @@ import tconstruct.library.tools.ToolMaterial;
 import tconstruct.library.util.ColorUtils;
 import tconstruct.library.util.HarvestLevels;
 import tconstruct.tools.logic.CraftingStationLogic;
+import tconstruct.util.config.PHConstruct;
 import tconstruct.util.network.CraftingStationDumpPacket;
 
 @Optional.Interface(iface = "codechicken.nei.api.INEIGuiHandler", modid = "NotEnoughItems")
@@ -40,6 +41,7 @@ public class CraftingStationGui extends GuiContainer implements INEIGuiHandler {
     private static final int DESCRIPTION_WIDTH = 126;
     private static final int DESCRIPTION_HEIGHT = 172;
     private static final int DEFAULT_COLUMNS = 6;
+    private static final int CLASSIC_MAX_ROWS = 10;
     private static final int MIN_COLUMNS = 5;
     private static final int MAX_OVERHANG_ROWS = 7;
     private static final int NEI_VERTICAL_MARGIN = 22;
@@ -688,8 +690,21 @@ public class CraftingStationGui extends GuiContainer implements INEIGuiHandler {
         int availableWidth = availableChestWidth + CRAFTING_WIDTH + descriptionWidth;
         int maxColumns = Math.max(MIN_COLUMNS, (availableChestWidth - border.w * 2) / slotElement.w);
 
+        if (PHConstruct.classicCraftingStationLayout) {
+            int totalRows = ceilDiv(chestSlotCount, DEFAULT_COLUMNS);
+            return createRectangularLayout(
+                    DEFAULT_COLUMNS,
+                    Math.min(totalRows, CLASSIC_MAX_ROWS),
+                    totalRows > CLASSIC_MAX_ROWS,
+                    headerHeight,
+                    descriptionWidth,
+                    sideHeight,
+                    Integer.MAX_VALUE,
+                    Integer.MAX_VALUE);
+        }
+
         // Preserve the original six-column layout for standard connected inventories.
-        if (chestSlotCount <= DEFAULT_COLUMNS * 10) {
+        if (chestSlotCount <= DEFAULT_COLUMNS * CLASSIC_MAX_ROWS) {
             return createRectangularLayout(
                     DEFAULT_COLUMNS,
                     ceilDiv(chestSlotCount, DEFAULT_COLUMNS),
@@ -784,8 +799,8 @@ public class CraftingStationGui extends GuiContainer implements INEIGuiHandler {
         int panelHeight = visibleRows * slotElement.h + headerHeight + border.h * 2;
         int combinedWidth = panelWidth + CRAFTING_WIDTH + descriptionWidth;
         int combinedHeight = Math.max(panelHeight, sideHeight);
-        int chestTopOffset = (combinedHeight - panelHeight) / 2;
-        int craftingTopOffset = (combinedHeight - sideHeight) / 2;
+        int chestTopOffset = PHConstruct.classicCraftingStationLayout ? 0 : (combinedHeight - panelHeight) / 2;
+        int craftingTopOffset = PHConstruct.classicCraftingStationLayout ? 0 : (combinedHeight - sideHeight) / 2;
         int totalRows = ceilDiv(chestSlotCount, columns);
         int visibleCapacity = columns * visibleRows;
         int unusedSlots = Math.max(0, visibleCapacity - chestSlotCount);

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -282,6 +282,12 @@ public class PHConstruct {
 
         showTravellerAccessories = config.get("Looks", "Show Traveller Gear Accessories", true).getBoolean(true);
         enableTinkerInventoryTab = config.get("Looks", "Enable Tinker Inventory Tab", true).getBoolean(true);
+        classicCraftingStationLayout = config.get(
+                "Looks",
+                "classicCraftingStationLayout",
+                false,
+                "Use the classic crafting station layout with at most 10 visible inventory rows and scrolling for larger inventories, client-side only")
+                .getBoolean(false);
 
         // dimension blacklist
         cfgForbiddenDim = config
@@ -568,6 +574,7 @@ public class PHConstruct {
     public static int connectedTexturesMode;
     public static boolean showTravellerAccessories;
     public static boolean enableTinkerInventoryTab;
+    public static boolean classicCraftingStationLayout;
 
     // dimensionblacklist
     public static boolean slimeIslGenDim0Only;


### PR DESCRIPTION
## Summary
adds the client-side `classicCraftingStationLayout` config option for players who prefer the layout from before #317
enabling it restores the top-aligned, six-column inventory panel with up to 10 visible rows and scrolling for larger inventories

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
