### PR TITLE
reduce lag from large smelteries

### DIFF
--- a/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
+++ b/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
@@ -43,7 +43,6 @@ public class SmelteryGui extends ActiveContainerGui {
     private final int columns;
     private final int smelterySize;
     public static final int maxRows = 8;
-    private int fuelDisplayTick = 0;
 
     public SmelteryGui(InventoryPlayer inventoryplayer, SmelteryLogic smeltery, World world, int x, int y, int z) {
         super((ActiveContainer) smeltery.getGuiContainer(inventoryplayer, world, x, y, z));
@@ -63,7 +62,6 @@ public class SmelteryGui extends ActiveContainerGui {
             return;
         }
 
-        if (fuelDisplayTick++ % 5 == 0) logic.updateFuelDisplay();
         updateScrollbar(mouseX, mouseY);
 
         super.drawScreen(mouseX, mouseY, par3);
@@ -280,10 +278,8 @@ public class SmelteryGui extends ActiveContainerGui {
         if (slotSize > columns * maxRows) slotSize = columns * maxRows;
         int iter;
         for (iter = 0; iter < slotSize && iter + slotPos * columns < smelterySize; iter++) {
-            int slotTemp = logic.getTempForSlot(iter + slotPos * columns) - 20;
-            int maxTemp = logic.getMeltingPointForSlot(iter + slotPos * columns) - 20;
-            if (slotTemp > 0 && maxTemp > 0) {
-                int size = Math.max(1, Math.min(16, 16 * slotTemp / maxTemp));
+            int size = ((SmelteryContainer) inventorySlots).getHeatLevel(iter + slotPos * columns);
+            if (size > 0) {
                 drawTexturedModalRect(
                         cornerX - xleft + (iter % columns * 22),
                         cornerY + 8 + (iter / columns * 18) + 16 - size,

--- a/src/main/java/tconstruct/smeltery/inventory/SmelteryContainer.java
+++ b/src/main/java/tconstruct/smeltery/inventory/SmelteryContainer.java
@@ -1,20 +1,32 @@
 package tconstruct.smeltery.inventory;
 
+import java.util.Arrays;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import tconstruct.TConstruct;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.smeltery.gui.SmelteryGui;
 import tconstruct.smeltery.logic.SmelteryLogic;
+import tconstruct.util.network.SmelteryGuiPacket;
 
 public class SmelteryContainer extends ActiveContainer {
 
     public SmelteryLogic logic;
     public InventoryPlayer playerInv;
-    public int fuel = 0;
+    private int updateTicks;
+    private int[] lastHeatRuns;
+    private FluidStack lastFuel;
+    private int lastFuelCapacity;
+    private final byte[] heatLevels;
     private int slotRow;
     public int columns;
     public final int smelterySize;
@@ -25,6 +37,7 @@ public class SmelteryContainer extends ActiveContainer {
         slotRow = 0;
         columns = smeltery.getBlocksPerLayer() >= 16 ? 4 : 3;
         smelterySize = smeltery.getBlockCapacity();
+        heatLevels = new byte[smelterySize];
 
         /* Smeltery inventory */
 
@@ -83,31 +96,65 @@ public class SmelteryContainer extends ActiveContainer {
     }
 
     @Override
-    public void detectAndSendChanges() // TODO: Sync with this
-    {
-        // we only update if the size is the same, since the screen is getting closed on sizechange and would cause a
-        // crash otherwise
-        if (smelterySize == this.inventorySlots.size()) super.detectAndSendChanges();
-        /*
-         * for (int i = 0; i < crafters.size(); i++) { ICrafting icrafting = (ICrafting)crafters.get(i); if (progress !=
-         * logic.progress) { icrafting.sendProgressBarUpdate(this, 0, logic.progress); } if (fuel != logic.fuel) {
-         * icrafting.sendProgressBarUpdate(this, 1, logic.fuel); } if (fuelGague != logic.fuelGague) {
-         * icrafting.sendProgressBarUpdate(this, 2, logic.fuelGague); } } progress = logic.progress; fuel = logic.fuel;
-         * fuelGague = logic.fuelGague;
-         */
+    public void detectAndSendChanges() {
+        // The GUI closes when the structure changes size. Its old Slot objects must not read the resized inventory.
+        if (smelterySize != logic.getBlockCapacity() || updateTicks++ % 5 != 0) return;
+        super.detectAndSendChanges();
+        if (crafters.isEmpty()) return;
+        logic.updateFuelDisplay();
+        int[] heatRuns = getHeatRuns();
+        FluidStack fuel = logic.getFuel();
+        if (!Arrays.equals(heatRuns, lastHeatRuns) || !fuel.isFluidStackIdentical(lastFuel)
+                || logic.fuelCapacity != lastFuelCapacity) {
+            for (Object crafter : crafters) {
+                if (crafter instanceof EntityPlayerMP player) {
+                    TConstruct.packetPipeline
+                            .sendTo(new SmelteryGuiPacket(this, heatRuns, fuel, logic.fuelCapacity), player);
+                }
+            }
+            lastHeatRuns = heatRuns;
+            lastFuel = fuel;
+            lastFuelCapacity = logic.fuelCapacity;
+        }
     }
 
     @Override
-    public void updateProgressBar(int id, int value) {
-        if (id == 0) {
-            logic.fuelGague = value;
+    public void addCraftingToCrafters(ICrafting crafter) {
+        super.addCraftingToCrafters(crafter);
+        if (crafter instanceof EntityPlayerMP player) {
+            logic.updateFuelDisplay();
+            TConstruct.packetPipeline
+                    .sendTo(new SmelteryGuiPacket(this, getHeatRuns(), logic.getFuel(), logic.fuelCapacity), player);
         }
-        /*
-         * if (id == 1) { logic.fuel = value; }
-         */
-        /*
-         * if (id == 2) { logic.fuelGague = value; }
-         */
+    }
+
+    private int[] getHeatRuns() {
+        IntArrayList runs = new IntArrayList();
+        int previous = -1;
+        for (int i = 0; i < smelterySize; i++) {
+            int temperature = logic.getTempForSlot(i) - 20;
+            int target = logic.getMeltingPointForSlot(i) - 20;
+            int level = temperature > 0 && target > 0 ? Math.max(1, Math.min(16, 16 * temperature / target)) : 0;
+            int run = ((i + 1) << 5) | level;
+            if (level == previous) runs.set(runs.size() - 1, run);
+            else runs.add(run);
+            previous = level;
+        }
+        return runs.toIntArray();
+    }
+
+    public void updateGuiState(int[] heatRuns, FluidStack fuel, int fuelCapacity) {
+        int start = 0;
+        for (int run : heatRuns) {
+            int end = run >>> 5;
+            Arrays.fill(heatLevels, start, end, (byte) (run & 31));
+            start = end;
+        }
+        logic.setFuelDisplay(fuel, fuelCapacity);
+    }
+
+    public int getHeatLevel(int slot) {
+        return heatLevels[slot];
     }
 
     @Override

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.monster.EntityIronGolem;
 import net.minecraft.entity.passive.EntityHorse;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
@@ -232,6 +233,10 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
     @Override
     public Container getGuiContainer(InventoryPlayer inventoryplayer, World world, int x, int y, int z) {
+        if (inventoryplayer.player instanceof EntityPlayerMP player) {
+            // The client needs the current capacity before constructing its slots, ahead of batched world updates.
+            player.playerNetServerHandler.sendPacket(getDescriptionPacket());
+        }
         return new SmelteryContainer(inventoryplayer, this);
     }
 

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -1,6 +1,8 @@
 package tconstruct.smeltery.logic;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -36,8 +38,6 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 import net.minecraftforge.fluids.IFluidTank;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import mantle.blocks.abstracts.InventoryLogic;
 import mantle.blocks.abstracts.MultiServantLogic;
 import mantle.blocks.iface.IActiveLogic;
@@ -85,6 +85,18 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
     public int[] activeTemps; // values are multiplied by 10
     public int[] meltingTemps; // values are multiplied by 10
+    private ItemStack[] cachedStacks = new ItemStack[0];
+    private ItemStack[] renderStacks = new ItemStack[0];
+    private FluidStack[] meltingResults = new FluidStack[0];
+    private boolean inventoryDirty = true;
+    private final BitSet heatingSlots = new BitSet();
+    private final BitSet waitingSlots = new BitSet();
+    private boolean tankChanged;
+    private NBTTagCompound lastSentClientData;
+    private NBTTagCompound lastReceivedClientData;
+    private int[] clientRenderRuns = new int[0];
+    private SmelteryRenderData renderData = new SmelteryRenderData(0, new int[0]);
+    private FluidStack displayFuel;
     private int tick;
     private boolean structureCheckQueued;
 
@@ -96,6 +108,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     boolean needsUpdate;
 
     private boolean drainComparatorOutputDirty;
+    private int lastComparatorStrength = -1;
 
     public SmelteryLogic() {
         super(0);
@@ -125,6 +138,8 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
             layers = lay;
             maxBlockCapacity = getBlocksPerLayer() * layers;
             maxLiquid = maxBlockCapacity * MB_PER_BLOCK_CAPACITY;
+            resetInventoryCache();
+            lastComparatorStrength = -1;
 
             int[] tempActive = activeTemps;
             activeTemps = new int[maxBlockCapacity];
@@ -206,6 +221,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
         // update current liquid. This is done in case some config or something changed the capacity or other things.
         updateCurrentLiquid();
+        drainComparatorOutputDirty = true;
     }
 
     /* Misc */
@@ -261,7 +277,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
     @Override
     public void setActive(boolean flag) {
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        needsUpdate = true;
     }
 
     public int getScaledFuelGague(int scale) {
@@ -288,6 +304,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     /* Updating */
     @Override
     public void updateEntity() {
+        if (worldObj.isRemote) return;
         checkStructureIfQueued();
 
         tick++;
@@ -296,14 +313,11 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
             detectEntities();
         }
 
-        /*
-         * if (worldObj.isRemote) return;
-         */
-
         if (tick % 4 == 0) {
             if (useTime > 0) useTime -= 4;
 
             if (validStructure) {
+                refreshInventory();
                 checkHasItems();
 
                 // consume fuel if needed
@@ -313,19 +327,25 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
             }
         }
 
+        if (tick % 5 == 0 && needsUpdate) {
+            NBTTagCompound data = writeClientData();
+            needsUpdate = false;
+            if (!data.equals(lastSentClientData)) {
+                lastSentClientData = data;
+                worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+            }
+        }
+
         if (tick % 20 == 0) {
             if (!validStructure) checkValidPlacement();
 
-            if (needsUpdate) {
-                needsUpdate = false;
-                worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-            }
-
             if (drainComparatorOutputDirty) {
-                // tank dirty, update drains
-                for (CoordTuple drain : drains) {
-                    // this obfuscated method will propagate a block update (and weak updates) around give coord
-                    worldObj.func_147453_f(drain.x, drain.y, drain.z, worldObj.getBlock(drain.x, drain.y, drain.z));
+                int strength = maxLiquid == 0 ? 0 : MathHelper.ceiling_float_int(15f * currentLiquid / maxLiquid);
+                if (strength != lastComparatorStrength) {
+                    lastComparatorStrength = strength;
+                    for (CoordTuple drain : drains) {
+                        worldObj.func_147453_f(drain.x, drain.y, drain.z, worldObj.getBlock(drain.x, drain.y, drain.z));
+                    }
                 }
                 drainComparatorOutputDirty = false;
             }
@@ -414,104 +434,118 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
         if (!itemDestroyed) item.setEntityItemStack(istack);
         if (itemAdded) {
-            this.needsUpdate = true;
-            // TODO 1.7.5 send description packet in better way to not cause render update
-            this.worldObj.markBlockForUpdate(this.xCoord, this.yCoord, this.zCoord);
+            markDirty();
         }
     }
 
     private void checkHasItems() {
-        inUse = false;
-        for (int i = 0; i < maxBlockCapacity; i++) if (this.isStackInSlot(i) && meltingTemps[i] > 200) {
-            inUse = true;
-            break;
-        }
+        inUse = !heatingSlots.isEmpty() || !waitingSlots.isEmpty();
     }
 
     private void heatItems() {
+        if (tankChanged) {
+            heatingSlots.or(waitingSlots);
+            waitingSlots.clear();
+            tankChanged = false;
+        }
         if (useTime > 0) {
-            boolean hasUse = false;
             int temperature = this.getInternalTemperature();
             int speed = temperature / 100;
             int refTemp = temperature * 10;
-            for (int i = 0; i < maxBlockCapacity; i++) {
+            for (int i = heatingSlots.nextSetBit(0); i >= 0; i = heatingSlots.nextSetBit(i + 1)) {
                 if (meltingTemps[i] > 200 && this.isStackInSlot(i)) {
-                    hasUse = true;
                     if (activeTemps[i] < refTemp && activeTemps[i] < meltingTemps[i]) {
+                        boolean wasVisible = activeTemps[i] / 10 > 20;
                         activeTemps[i] += speed; // lava has temp of 1000. we increase by 10 per application.
+                        if (!wasVisible && activeTemps[i] / 10 > 20) needsUpdate = true;
                     } else if (activeTemps[i] >= meltingTemps[i]) {
-                        if (!worldObj.isRemote) {
-                            FluidStack result = getResultFor(inventory[i]);
-                            if (result != null) {
-                                if (addMoltenMetal(result, false)) {
-                                    inventory[i] = null;
-                                    activeTemps[i] = 200;
-                                    ArrayList<FluidStack> alloys = Smeltery.mixMetals(moltenMetal);
-                                    for (FluidStack liquid : alloys) {
-                                        addMoltenMetal(liquid, true);
-                                    }
-                                    markDirty();
-                                }
-                            }
+                        FluidStack result = meltingResults[i];
+                        if (result != null && result.amount <= maxLiquid - currentLiquid
+                                && addMoltenMetal(result, false)) {
+                            inventory[i] = null;
+                            activeTemps[i] = 200;
+                            meltingTemps[i] = 200;
+                            cachedStacks[i] = null;
+                            meltingResults[i] = null;
+                            renderStacks[i] = null;
+                            heatingSlots.clear(i);
+                            mixMetals();
+                        } else {
+                            heatingSlots.clear(i);
+                            waitingSlots.set(i);
                         }
                     }
 
-                } else activeTemps[i] = 200;
+                } else {
+                    activeTemps[i] = 200;
+                    heatingSlots.clear(i);
+                }
             }
-            inUse = hasUse;
+            checkHasItems();
         }
     }
 
     boolean addMoltenMetal(FluidStack liquid, boolean first) {
-        needsUpdate = true;
-        if (moltenMetal.size() == 0) {
-            // does it fit in?
-            if (liquid.amount > this.getCapacity()) return false;
-
-            moltenMetal.add(liquid.copy());
-            updateCurrentLiquid();
-        } else {
-            // update liquid amount..
-            updateCurrentLiquid();
-
-            if (liquid.amount + currentLiquid > maxLiquid) return false;
-
-            currentLiquid += liquid.amount;
-            drainComparatorOutputDirty = true;
-            // TConstruct.logger.info("Current liquid: "+currentLiquid);
-            boolean added = false;
-            for (int i = 0; i < moltenMetal.size(); i++) {
-                FluidStack l = moltenMetal.get(i);
-                // if (l.itemID == liquid.itemID && l.itemMeta ==
-                // liquid.itemMeta)
-                if (l.isFluidEqual(liquid)) {
-                    l.amount += liquid.amount;
-                    added = true;
-                }
-                if (l.amount <= 0) {
-                    moltenMetal.remove(l);
-                    i--;
-                }
-            }
-            if (!added) {
-                if (first) moltenMetal.add(0, liquid.copy());
-                else moltenMetal.add(liquid.copy());
+        // Alloy recipes consume the existing stacks before returning their products.
+        updateCurrentLiquid();
+        if (liquid.amount <= 0 || liquid.amount > maxLiquid - currentLiquid) return false;
+        moltenMetal.removeIf(fluid -> fluid.amount <= 0);
+        for (FluidStack stored : moltenMetal) {
+            if (stored.isFluidEqual(liquid)) {
+                stored.amount += liquid.amount;
+                currentLiquid += liquid.amount;
+                markTankDirty();
+                return true;
             }
         }
+        moltenMetal.add(first ? 0 : moltenMetal.size(), liquid.copy());
+        currentLiquid += liquid.amount;
+        markTankDirty();
         return true;
     }
 
     private void updateCurrentLiquid() {
         currentLiquid = 0;
         for (FluidStack liquid : moltenMetal) currentLiquid += liquid.amount;
-        drainComparatorOutputDirty = true;
     }
 
-    private void updateTemperatures() {
-        for (int i = 0; i < maxBlockCapacity && i < meltingTemps.length; i++) {
-            meltingTemps[i] = Smeltery.getLiquifyTemperature(inventory[i]) * 10; // temperatures are *10 for more
-                                                                                 // progress control
+    private void mixMetals() {
+        for (FluidStack liquid : Smeltery.mixMetals(moltenMetal)) {
+            addMoltenMetal(liquid, true);
         }
+    }
+
+    private void resetInventoryCache() {
+        heatingSlots.clear();
+        waitingSlots.clear();
+        cachedStacks = new ItemStack[maxBlockCapacity];
+        renderStacks = new ItemStack[maxBlockCapacity];
+        meltingResults = new FluidStack[maxBlockCapacity];
+        inventoryDirty = true;
+    }
+
+    private void refreshInventory() {
+        if (!inventoryDirty) return;
+        inventoryDirty = false;
+        for (int i = 0; i < maxBlockCapacity; i++) {
+            ItemStack stack = inventory[i];
+            if (!ItemStack.areItemStacksEqual(stack, cachedStacks[i])) {
+                cachedStacks[i] = stack == null ? null : stack.copy();
+                meltingTemps[i] = Smeltery.getLiquifyTemperature(stack) * 10;
+                meltingResults[i] = getResultFor(stack);
+                renderStacks[i] = stack == null ? null : Smeltery.getRenderIndex(stack);
+                waitingSlots.clear(i);
+                heatingSlots.set(i, stack != null && meltingTemps[i] > 200);
+                if (!heatingSlots.get(i)) activeTemps[i] = 200;
+            }
+        }
+    }
+
+    private void markTankDirty() {
+        tankChanged = true;
+        needsUpdate = true;
+        drainComparatorOutputDirty = true;
+        super.markDirty();
     }
 
     public void updateFuelDisplay() {
@@ -549,6 +583,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
         fuelAmount = totalAmount;
         fuelCapacity = totalCapacity;
+        displayFuel = fuelType == null ? null : new FluidStack(fuelType, totalAmount);
     }
 
     // actually is updateFuel.
@@ -623,37 +658,14 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
         // empty
     }
 
-    @SideOnly(Side.CLIENT)
     public FluidStack getFuel() {
-        FluidStack combined = null;
+        return displayFuel == null ? new FluidStack(FluidRegistry.LAVA, 0) : displayFuel.copy();
+    }
 
-        synchronized (lavaTanks) {
-            Iterator<CoordTuple> iter = lavaTanks.iterator();
-            while (iter.hasNext()) {
-                CoordTuple coord = iter.next();
-                if (!worldObj.blockExists(coord.x, coord.y, coord.z)) continue;
-
-                TileEntity te = worldObj.getTileEntity(coord.x, coord.y, coord.z);
-                if (!(te instanceof IFluidHandler)) {
-                    iter.remove();
-                    continue;
-                }
-
-                FluidTankInfo[] info = ((IFluidHandler) te).getTankInfo(ForgeDirection.DOWN);
-                if (info.length <= 0 || info[0].fluid == null || info[0].fluid.amount <= 0) continue;
-
-                if (combined == null) {
-                    combined = info[0].fluid.copy();
-                } else if (combined.isFluidEqual(info[0].fluid)) {
-                    combined.amount += info[0].fluid.amount;
-                }
-            }
-        }
-
-        if (combined == null) {
-            return new FluidStack(FluidRegistry.LAVA, 0);
-        }
-        return combined;
+    public void setFuelDisplay(FluidStack fuel, int capacity) {
+        displayFuel = fuel;
+        fuelAmount = fuel == null ? 0 : fuel.amount;
+        fuelCapacity = capacity;
     }
 
     public FluidStack getResultFor(ItemStack stack) {
@@ -673,7 +685,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
     @Override
     public void markDirty() {
-        updateTemperatures();
+        inventoryDirty = true;
 
         super.markDirty();
         needsUpdate = true;
@@ -809,11 +821,11 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
                 // update other stuff
                 adjustLayers(checkLayers, true);
-                worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+                needsUpdate = true;
                 validStructure = true;
             } else {
                 internalTemp = 20;
-                if (validStructure) worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+                if (validStructure) needsUpdate = true;
                 validStructure = false;
             }
         }
@@ -990,18 +1002,15 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
                 if (doDrain) {
                     // liquid = null;
                     moltenMetal.remove(liquid);
-                    worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-                    needsUpdate = true;
                     updateCurrentLiquid();
+                    markTankDirty();
                 }
                 return liq;
             } else {
                 if (doDrain && maxDrain > 0) {
                     liquid.amount -= maxDrain;
-                    worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
                     currentLiquid -= maxDrain;
-                    drainComparatorOutputDirty = true;
-                    needsUpdate = true;
+                    markTankDirty();
                 }
                 return new FluidStack(liquid.getFluid(), maxDrain, liquid.tag);
             }
@@ -1012,28 +1021,14 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
     @Override
     public int fill(FluidStack resource, boolean doFill) {
-        // don't fill if we're not complete
-        if (!validStructure) return 0;
-
-        if (resource != null && currentLiquid < maxLiquid) // resource.amount +
-        // currentLiquid <
-        // maxLiquid)
-        {
-            if (resource.amount + currentLiquid > maxLiquid) resource.amount = maxLiquid - currentLiquid;
-            int amount = resource.amount;
-
-            if (amount > 0 && doFill) {
-                if (addMoltenMetal(resource, false)) {
-                    ArrayList<FluidStack> alloys = Smeltery.mixMetals(moltenMetal);
-                    for (FluidStack liquid : alloys) {
-                        addMoltenMetal(liquid, true);
-                    }
-                }
-                needsUpdate = true;
-                worldObj.func_147479_m(xCoord, yCoord, zCoord);
-            }
-            return amount;
-        } else return 0;
+        if (!validStructure || resource == null || resource.amount <= 0) return 0;
+        int amount = Math.min(resource.amount, Math.max(0, maxLiquid - currentLiquid));
+        if (amount == 0 || !doFill) return amount;
+        FluidStack accepted = resource.copy();
+        accepted.amount = amount;
+        if (!addMoltenMetal(accepted, false)) return 0;
+        mixMetals();
+        return amount;
     }
 
     @Override
@@ -1076,6 +1071,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
         else maxPos = new CoordTuple(xCoord, yCoord, zCoord);
 
         maxBlockCapacity = getBlocksPerLayer() * layers;
+        resetInventoryCache();
         inventory = new ItemStack[maxBlockCapacity];
         super.readFromNBT(tags);
 
@@ -1149,19 +1145,80 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     }
 
     /* Packets */
+    private NBTTagCompound writeClientData() {
+        refreshInventory();
+        NBTTagCompound data = new NBTTagCompound();
+        data.setBoolean("ValidStructure", validStructure);
+        data.setIntArray("MinPos", new int[] { minPos.x, minPos.y, minPos.z });
+        data.setIntArray("MaxPos", new int[] { maxPos.x, maxPos.y, maxPos.z });
+        data.setInteger("Layers", layers);
+        data.setInteger("MaxLiquid", maxLiquid);
+        data.setByte("Direction", direction);
+        data.setIntArray("Render", SmelteryRenderData.encode(inventory, renderStacks, activeTemps));
+        NBTTagList fluids = new NBTTagList();
+        for (FluidStack fluid : moltenMetal) fluids.appendTag(fluid.copy().writeToNBT(new NBTTagCompound()));
+        data.setTag("Liquids", fluids);
+        return data;
+    }
+
+    public SmelteryRenderData getRenderData() {
+        return renderData;
+    }
+
+    public void reorderFluid(int fluidId, boolean last) {
+        for (int i = 0; i < moltenMetal.size(); i++) {
+            if (moltenMetal.get(i).getFluidID() == fluidId) {
+                int target = last ? moltenMetal.size() - 1 : 0;
+                if (i != target) {
+                    moltenMetal.add(target, moltenMetal.remove(i));
+                    markTankDirty();
+                }
+                return;
+            }
+        }
+    }
+
     @Override
     public Packet getDescriptionPacket() {
-        NBTTagCompound tag = new NBTTagCompound();
-        writeToNBT(tag);
-        return new S35PacketUpdateTileEntity(xCoord, yCoord, zCoord, 1, tag);
+        return new S35PacketUpdateTileEntity(xCoord, yCoord, zCoord, 1, writeClientData());
     }
 
     @Override
     public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity packet) {
-        readFromNBT(packet.func_148857_g());
-        markDirty();
+        NBTTagCompound data = packet.func_148857_g();
+        if (data.equals(lastReceivedClientData)) return;
+        lastReceivedClientData = (NBTTagCompound) data.copy();
+        int[] min = data.getIntArray("MinPos");
+        int[] max = data.getIntArray("MaxPos");
+        minPos = new CoordTuple(min[0], min[1], min[2]);
+        maxPos = new CoordTuple(max[0], max[1], max[2]);
+        layers = data.getInteger("Layers");
+        maxLiquid = data.getInteger("MaxLiquid");
+        direction = data.getByte("Direction");
+        validStructure = data.getBoolean("ValidStructure");
+        int size = getBlocksPerLayer() * layers;
+        boolean resized = size != maxBlockCapacity;
+        if (resized) {
+            maxBlockCapacity = size;
+            inventory = new ItemStack[size];
+            activeTemps = new int[size];
+            meltingTemps = new int[size];
+        }
+        int[] runs = data.getIntArray("Render");
+        if (resized || !Arrays.equals(runs, clientRenderRuns)) {
+            clientRenderRuns = runs;
+            renderData = new SmelteryRenderData(size, runs);
+        }
+        NBTTagList fluids = data.getTagList("Liquids", 10);
+        synchronized (moltenMetal) {
+            moltenMetal.clear();
+            for (int i = 0; i < fluids.tagCount(); i++) {
+                FluidStack fluid = FluidStack.loadFluidStackFromNBT(fluids.getCompoundTagAt(i));
+                if (fluid != null) moltenMetal.add(fluid);
+            }
+            updateCurrentLiquid();
+        }
         worldObj.func_147479_m(xCoord, yCoord, zCoord);
-        this.needsUpdate = true;
     }
 
     @Override

--- a/src/main/java/tconstruct/smeltery/logic/SmelteryRenderData.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryRenderData.java
@@ -1,0 +1,78 @@
+package tconstruct.smeltery.logic;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MathHelper;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
+/** The block appearance of the contents, independent of the GUI's actual inventory stacks. */
+public final class SmelteryRenderData {
+
+    private final int[] blocks;
+    private final int[] metadata;
+    private final float[] heights;
+
+    public SmelteryRenderData(int size, int[] runs) {
+        blocks = new int[size];
+        metadata = new int[size];
+        heights = new float[size];
+        int start = 0;
+        for (int i = 0; i < runs.length; i += 4) {
+            int end = runs[i];
+            java.util.Arrays.fill(blocks, start, end, runs[i + 1]);
+            java.util.Arrays.fill(metadata, start, end, runs[i + 2]);
+            java.util.Arrays.fill(heights, start, end, Float.intBitsToFloat(runs[i + 3]));
+            start = end;
+        }
+    }
+
+    /** Each run stores its exclusive end, block ID, metadata and exact rendered height. */
+    public static int[] encode(ItemStack[] inventory, ItemStack[] renderStacks, int[] temperatures) {
+        IntArrayList runs = new IntArrayList();
+        int previousBlock = -1;
+        int previousMeta = 0;
+        int previousHeight = 0;
+        for (int slot = 0; slot < inventory.length; slot++) {
+            int block = 0;
+            int meta = 0;
+            int height = 0;
+            ItemStack input = inventory[slot];
+            ItemStack render = renderStacks[slot];
+            if (input != null && render != null && temperatures[slot] / 10 > 20) {
+                block = Block.getIdFromBlock(Block.getBlockFromItem(render.getItem()));
+                meta = render.getItemDamage();
+                height = Float.floatToIntBits(
+                        MathHelper.clamp_float(input.stackSize / (float) render.stackSize, 0.01F, 1.0F));
+            }
+            if (block == previousBlock && meta == previousMeta && height == previousHeight) {
+                runs.set(runs.size() - 4, slot + 1);
+            } else {
+                runs.add(slot + 1);
+                runs.add(block);
+                runs.add(meta);
+                runs.add(height);
+                previousBlock = block;
+                previousMeta = meta;
+                previousHeight = height;
+            }
+        }
+        return runs.toIntArray();
+    }
+
+    public Block getBlock(int slot) {
+        return Block.getBlockById(blocks[slot]);
+    }
+
+    public int size() {
+        return blocks.length;
+    }
+
+    public int getMetadata(int slot) {
+        return metadata[slot];
+    }
+
+    public float getHeight(int slot) {
+        return heights[slot];
+    }
+}

--- a/src/main/java/tconstruct/smeltery/model/SmelteryRender.java
+++ b/src/main/java/tconstruct/smeltery/model/SmelteryRender.java
@@ -2,8 +2,6 @@ package tconstruct.smeltery.model;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -14,8 +12,8 @@ import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import mantle.world.CoordTuple;
 import tconstruct.client.BlockSkinRenderHelper;
-import tconstruct.library.crafting.Smeltery;
 import tconstruct.smeltery.logic.SmelteryLogic;
+import tconstruct.smeltery.logic.SmelteryRenderData;
 import tconstruct.util.ItemHelper;
 
 @ThreadSafeISBRH(perThread = false)
@@ -115,33 +113,15 @@ public class SmelteryRender implements ISimpleBlockRenderingHandler {
     void renderLayer(SmelteryLogic logic, int start, CoordTuple from, CoordTuple to, int posY, RenderBlocks renderer,
             IBlockAccess world) {
         renderer.setRenderBounds(-0.001F, -0.001F, -0.001F, 1.001F, 1.001F, 1.001F);
+        SmelteryRenderData data = logic.getRenderData();
         int i = start;
         for (int x = from.x; x <= to.x; x++) for (int z = from.z; z <= to.z; z++) {
-            // safety because of changes.
-            if (i > logic.getSizeInventory()) return;
-            ItemStack input = logic.getStackInSlot(i);
-            if (input != null && logic.getTempForSlot(i) > 20) {
-                ItemStack blockToRender = Smeltery.getRenderIndex(input);
-                if (blockToRender != null) {
-                    float blockHeight = input.stackSize / (float) blockToRender.stackSize;
-                    renderer.setRenderBounds(
-                            0.0F,
-                            0.0F,
-                            0.0F,
-                            1.0F,
-                            MathHelper.clamp_float(blockHeight, 0.01F, 1.0F),
-                            1.0F);
-
-                    Block liquidBlock = Block.getBlockFromItem(blockToRender.getItem());
-                    BlockSkinRenderHelper.renderMetadataBlock(
-                            liquidBlock,
-                            blockToRender.getItemDamage(),
-                            x,
-                            posY,
-                            z,
-                            renderer,
-                            world);
-                }
+            if (i >= data.size()) return;
+            float height = data.getHeight(i);
+            if (height > 0) {
+                renderer.setRenderBounds(0.0F, 0.0F, 0.0F, 1.0F, height, 1.0F);
+                BlockSkinRenderHelper
+                        .renderMetadataBlock(data.getBlock(i), data.getMetadata(i), x, posY, z, renderer, world);
             }
             i++;
         }

--- a/src/main/java/tconstruct/util/network/PacketPipeline.java
+++ b/src/main/java/tconstruct/util/network/PacketPipeline.java
@@ -124,6 +124,7 @@ public class PacketPipeline extends MessageToMessageCodec<FMLProxyPacket, Abstra
         registerPacket(DoubleJumpPacket.class);
         registerPacket(AccessoryInventoryPacket.class);
         registerPacket(SmelteryPacket.class);
+        registerPacket(SmelteryGuiPacket.class);
         registerPacket(PatternTablePacket.class);
         registerPacket(ToolStationPacket.class);
         registerPacket(PacketUpdateTE.class);

--- a/src/main/java/tconstruct/util/network/SmelteryGuiPacket.java
+++ b/src/main/java/tconstruct/util/network/SmelteryGuiPacket.java
@@ -1,0 +1,66 @@
+package tconstruct.util.network;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.FluidStack;
+
+import cpw.mods.fml.common.network.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import mantle.common.network.AbstractPacket;
+import tconstruct.smeltery.inventory.SmelteryContainer;
+
+/** Heat-bar levels and aggregate fuel, sent only to an open smeltery container. */
+public class SmelteryGuiPacket extends AbstractPacket {
+
+    private int windowId;
+    private int slots;
+    private int[] heatRuns;
+    private FluidStack fuel;
+    private int fuelCapacity;
+
+    public SmelteryGuiPacket() {}
+
+    public SmelteryGuiPacket(SmelteryContainer container, int[] heatRuns, FluidStack fuel, int fuelCapacity) {
+        windowId = container.windowId;
+        slots = container.smelterySize;
+        this.heatRuns = heatRuns.clone();
+        this.fuel = fuel.copy();
+        this.fuelCapacity = fuelCapacity;
+    }
+
+    @Override
+    public void encodeInto(ChannelHandlerContext ctx, ByteBuf buffer) {
+        buffer.writeInt(windowId);
+        buffer.writeInt(slots);
+        buffer.writeInt(heatRuns.length);
+        for (int run : heatRuns) buffer.writeInt(run);
+        ByteBufUtils.writeTag(buffer, fuel.writeToNBT(new NBTTagCompound()));
+        buffer.writeInt(fuelCapacity);
+    }
+
+    @Override
+    public void decodeInto(ChannelHandlerContext ctx, ByteBuf buffer) {
+        windowId = buffer.readInt();
+        slots = buffer.readInt();
+        int length = buffer.readInt();
+        if (slots < 0 || length < 0 || length > slots || length > buffer.readableBytes() / Integer.BYTES) {
+            throw new IllegalArgumentException("Invalid smeltery heat run count");
+        }
+        heatRuns = new int[length];
+        for (int i = 0; i < heatRuns.length; i++) heatRuns[i] = buffer.readInt();
+        fuel = FluidStack.loadFluidStackFromNBT(ByteBufUtils.readTag(buffer));
+        fuelCapacity = buffer.readInt();
+    }
+
+    @Override
+    public void handleClientSide(EntityPlayer player) {
+        if (player.openContainer instanceof SmelteryContainer container && container.windowId == windowId
+                && container.smelterySize == slots) {
+            container.updateGuiState(heatRuns, fuel, fuelCapacity);
+        }
+    }
+
+    @Override
+    public void handleServerSide(EntityPlayer player) {}
+}

--- a/src/main/java/tconstruct/util/network/SmelteryPacket.java
+++ b/src/main/java/tconstruct/util/network/SmelteryPacket.java
@@ -1,14 +1,10 @@
 package tconstruct.util.network;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.fluids.FluidStack;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import mantle.common.network.AbstractPacket;
-import mantle.common.network.PacketUpdateTE;
-import tconstruct.TConstruct;
 import tconstruct.smeltery.inventory.SmelteryContainer;
 import tconstruct.smeltery.logic.SmelteryLogic;
 
@@ -61,22 +57,7 @@ public class SmelteryPacket extends AbstractPacket {
                     && logic.xCoord == this.x
                     && logic.yCoord == this.y
                     && logic.zCoord == this.z) {
-                FluidStack temp = null;
-
-                for (FluidStack liquid : logic.moltenMetal) {
-                    if (liquid.getFluidID() == this.fluidID) temp = liquid;
-                }
-
-                if (temp != null) {
-                    logic.moltenMetal.remove(temp);
-                    if (this.isShiftPressed) logic.moltenMetal.add(temp);
-                    else logic.moltenMetal.add(0, temp);
-                }
-
-                NBTTagCompound data = new NBTTagCompound();
-                logic.writeToNBT(data);
-                TConstruct.packetPipeline
-                        .sendToDimension(new PacketUpdateTE(this.x, this.y, this.z, data), this.dimension);
+                logic.reorderFluid(this.fluidID, this.isShiftPressed);
             }
         }
     }


### PR DESCRIPTION
## Summary
large smelteries kept checking items that could not melt because the tank was full
they now wait until the tank changes before trying again
melting recipes are cached instead of being looked up repeatedly

updates now send only the data needed to display the smeltery
full item data is sent separately to players with the GUI open
updates are grouped and sent less often

also fixes item updates in the GUI
filling the tank now leaves the other mod's fluid data unchanged

fullpack testing showed much lower tick times and less time spent compressing NBT

before: https://spark.lucko.me/ZCpUv2EGri

after: https://spark.lucko.me/ibSphm7A9T

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
